### PR TITLE
:sparkles: [feat]: 로그인 api 구현

### DIFF
--- a/src/main/java/com/app/demo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/app/demo/apiPayload/code/status/ErrorStatus.java
@@ -25,13 +25,14 @@ public enum ErrorStatus implements BaseErrorCode {
     // Auth 관련
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "토큰이 만료되었습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 유효하지 않습니다."),
-    INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_003", "올바른 이메일이나 패스워드가 아닙니다."),
-    INVALID_REQUEST_INFO(HttpStatus.UNAUTHORIZED, "AUTH_006", "카카오 정보 불러오기에 실패하였습니다."),
-    NOT_EQUAL_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_007", "리프레시 토큰이 다릅니다."),
-    NOT_CONTAIN_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_008", "해당하는 토큰이 저장되어있지 않습니다."),
+    INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_003", "올바른 아이디나 패스워드가 아닙니다."),
+    NOT_EQUAL_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "리프레시 토큰이 다릅니다."),
+    NOT_CONTAIN_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_005", "해당하는 토큰이 저장되어있지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_006", "비밀번호가 일치하지 않습니다."),
 
     // User 관련
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_004", "존재하지 않는 사용자입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "존재하지 않는 사용자입니다."),
+    USER_EXISTS(HttpStatus.BAD_REQUEST, "USER_002", "이미 존재하는 아이디입니다."),
 
     //Search 관련
     SEARCH_CONDITION_INVALID(HttpStatus.BAD_REQUEST, "SEARCH_001", "검색 조건이 하나라도 존재해야 합니다."),

--- a/src/main/java/com/app/demo/config/SecurityConfig.java
+++ b/src/main/java/com/app/demo/config/SecurityConfig.java
@@ -1,50 +1,68 @@
 package com.app.demo.config;
 
-import lombok.RequiredArgsConstructor;
+import com.app.demo.security.filter.AuthExceptionHandlingFilter;
+import com.app.demo.security.filter.JwtRequestFilter;
+import com.app.demo.security.handler.JwtAccessDeniedHandler;
+import com.app.demo.security.handler.JwtAuthenticationEntryPoint;
+import jakarta.servlet.Filter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-/*
-    private final JwtTokenProvider jwtTokenProvider;
-    public SecurityConfig(JwtTokenProvider jwtTokenProvider){
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
-*/
+
+    private final JwtRequestFilter jwtRequestFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final AuthExceptionHandlingFilter authExceptionHandlingFilter;
+
+    private final String[] allowedUrls = {
+            "/api/signup",
+            "/api/login",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+            "/**"
+    };
+
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .authorizeHttpRequests((auth)-> auth
-                        .requestMatchers("/login","/join","joinProc","/swagger-ui/**", "/v3/api-docs/**", "/**").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .formLogin((form) -> form
-                        .loginPage("/login")  // 로그인 페이지
-                        .loginProcessingUrl("/loginProc")  // 로그인 처리 URL
-                        .defaultSuccessUrl("/", true)  // 로그인 성공 시 리디렉션 경로
-                        .permitAll()  // 모든 사용자가 로그인 페이지 접근 허용
-                )
-                .logout((logout) -> logout
-                        .logoutUrl("/logout")  // 로그아웃 처리 URL
-                        .logoutSuccessUrl("/login?logout")  // 로그아웃 성공 후 리디렉션 경로
-                        .permitAll()  // 로그아웃 URL 접근 허용
-                )
-                .csrf(csrf -> csrf.disable()); // CSRF 보호 비활성화
+                .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화
+                .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화
+                .headers(headers -> headers
+                        .permissionsPolicy(policy -> policy.policy("frame-ancestors 'self'"))) // 헤더 설정
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 정책을 STATELESS로 설정
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/signup", "/api/login", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(authExceptionHandlingFilter, JwtRequestFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/app/demo/config/SecurityConfig.java
+++ b/src/main/java/com/app/demo/config/SecurityConfig.java
@@ -31,15 +31,6 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final AuthExceptionHandlingFilter authExceptionHandlingFilter;
 
-    private final String[] allowedUrls = {
-            "/api/signup",
-            "/api/login",
-            "/swagger-ui/**",
-            "/swagger-resources/**",
-            "/v3/api-docs/**",
-            "/**"
-    };
-
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -59,7 +50,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/signup", "/api/login", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/member/signup", "/api/member/login", "api/music/search","/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(authExceptionHandlingFilter, JwtRequestFilter.class);

--- a/src/main/java/com/app/demo/config/SecurityConfig.java
+++ b/src/main/java/com/app/demo/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/member/signup", "/api/member/login", "api/music/search","/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/member/signup", "/api/member/login", "api/music/search","/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**", "/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(authExceptionHandlingFilter, JwtRequestFilter.class);

--- a/src/main/java/com/app/demo/config/SwaggerConfig.java
+++ b/src/main/java/com/app/demo/config/SwaggerConfig.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,16 +16,22 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
-        String jwt = "JWT";
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
-        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
-                .name(jwt)
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT")
-        );
+
+        String jwtSchemeName = "JWT TOKEN";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components =
+                new Components()
+                        .addSecuritySchemes(
+                                jwtSchemeName,
+                                new SecurityScheme()
+                                        .name(jwtSchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("Bearer")
+                                        .bearerFormat("JWT"));
+
         return new OpenAPI()
-                .components(new Components())
+                .addServersItem(new Server().url("/"))
                 .info(apiInfo())
                 .addSecurityItem(securityRequirement)
                 .components(components);

--- a/src/main/java/com/app/demo/config/WebConfig.java
+++ b/src/main/java/com/app/demo/config/WebConfig.java
@@ -1,6 +1,8 @@
 package com.app.demo.config;
 
 import java.util.List;
+
+import com.app.demo.security.handler.resolver.ExtractTokenArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -13,8 +15,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-//    private final AuthUserArgumentResolver authUserArgumentResolver;
-//    private final ExtractTokenArgumentResolver extractTokenArgumentResolver;
+    private final ExtractTokenArgumentResolver extractTokenArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -41,7 +42,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-//        resolvers.add(authUserArgumentResolver);
-//        resolvers.add(extractTokenArgumentResolver);
+        resolvers.add(extractTokenArgumentResolver);
     }
 }

--- a/src/main/java/com/app/demo/controller/MemberController.java
+++ b/src/main/java/com/app/demo/controller/MemberController.java
@@ -15,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
 
 @RestController
 @RequestMapping("api/member")
@@ -37,17 +36,17 @@ public class MemberController {
     @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회 성공")})
     @Operation(summary = "로그인", description = "로그인 API입니다.")
     @PostMapping("/login")
-    private BaseResponse<LoginResponseDTO.JwtToken> login(@RequestBody LoginRequestDTO loginRequest){
-        LoginResponseDTO.JwtToken token = memberService.login(loginRequest);
-        return BaseResponse.onSuccess(token);
+    private BaseResponse<LoginResponseDTO.OAuthResponse> login(@RequestBody LoginRequestDTO loginRequest){
+        LoginResponseDTO.OAuthResponse response = memberService.login(loginRequest);
+        return BaseResponse.onSuccess(response);
     }
 
+    @ResponseStatus(code = HttpStatus.OK)
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회 성공")})
     @Operation(summary = "JWT Access Token 재발급 API", description = "Refresh Token을 검증하고 새로운 Access Token과 Refresh Token을 응답합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-    })
     @PostMapping("/refresh")
     public BaseResponse<TokenRefreshResponse> refresh(@ExtractToken String refreshToken) {
-        return BaseResponse.onSuccess(memberService.refresh(refreshToken));
+        TokenRefreshResponse response = memberService.refresh(refreshToken);
+        return BaseResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/app/demo/controller/MemberController.java
+++ b/src/main/java/com/app/demo/controller/MemberController.java
@@ -2,6 +2,10 @@ package com.app.demo.controller;
 
 import com.app.demo.apiPayload.BaseResponse;
 import com.app.demo.dto.MemberSignupDTO;
+import com.app.demo.dto.request.LoginRequestDTO;
+import com.app.demo.dto.response.LoginResponseDTO;
+import com.app.demo.dto.response.TokenRefreshResponse;
+import com.app.demo.security.handler.annotation.ExtractToken;
 import com.app.demo.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -10,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("api/member")
@@ -21,9 +27,27 @@ public class MemberController {
     @ResponseStatus(code = HttpStatus.CREATED)
     @Operation(summary = "회원가입", description = "회원가입 API입니다.")
     @ApiResponses({@ApiResponse(responseCode = "COMMON201", description = "등록 성공")})
-    @PostMapping("/sign-up")
+    @PostMapping("/signup")
     public BaseResponse<String> signUp(@RequestBody MemberSignupDTO memberSignUpDto) throws Exception {
         memberService.signUp(memberSignUpDto);
         return BaseResponse.onSuccess("회원가입 성공");
+    }
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회 성공")})
+    @Operation(summary = "로그인", description = "로그인 API입니다.")
+    @PostMapping("/login")
+    private BaseResponse<LoginResponseDTO.JwtToken> login(@RequestBody LoginRequestDTO loginRequest){
+        LoginResponseDTO.JwtToken token = memberService.login(loginRequest);
+        return BaseResponse.onSuccess(token);
+    }
+
+    @Operation(summary = "JWT Access Token 재발급 API", description = "Refresh Token을 검증하고 새로운 Access Token과 Refresh Token을 응답합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @PostMapping("/refresh")
+    public BaseResponse<TokenRefreshResponse> refresh(@ExtractToken String refreshToken) {
+        return BaseResponse.onSuccess(memberService.refresh(refreshToken));
     }
 }

--- a/src/main/java/com/app/demo/controller/MusicController.java
+++ b/src/main/java/com/app/demo/controller/MusicController.java
@@ -33,7 +33,7 @@ public class MusicController {
 
     @ResponseStatus(code = HttpStatus.OK)
     @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회 성공")})
-    @Operation(summary = "accessToken발급", description = "토큰 받아오는 API입니다.")
+    @Operation(summary = "SpotifyAccessToken발급", description = "Spotify 토큰 받아오는 API입니다.")
     @GetMapping("/getToken")
     private BaseResponse<String> getSpotifyToken(){
         String token = musicService.getAccessToken();

--- a/src/main/java/com/app/demo/converter/MemberConverter.java
+++ b/src/main/java/com/app/demo/converter/MemberConverter.java
@@ -1,0 +1,18 @@
+package com.app.demo.converter;
+
+import com.app.demo.dto.response.LoginResponseDTO;
+import com.app.demo.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberConverter {
+    public LoginResponseDTO.OAuthResponse convertToOAuthResponse(Member member, String accessToken, String refreshToken) {
+        return LoginResponseDTO.OAuthResponse.builder()
+                .memberId(member.getMemberId())
+                .nickname(member.getNickname())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isLogin(true)
+                .build();
+    }
+}

--- a/src/main/java/com/app/demo/dto/request/LoginRequestDTO.java
+++ b/src/main/java/com/app/demo/dto/request/LoginRequestDTO.java
@@ -1,0 +1,15 @@
+package com.app.demo.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDTO {
+
+    @NotBlank(message = "아이디는 필수입니다.")
+    private String userID;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/app/demo/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/app/demo/dto/response/LoginResponseDTO.java
@@ -1,0 +1,28 @@
+package com.app.demo.dto.response;
+
+
+import lombok.*;
+
+public class LoginResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class OAuthResponse {
+        Long userId;
+        String accessToken;
+        String refreshToken;
+        Boolean isLogin;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class JwtToken {
+        String grantType;
+        String accessToken;
+        String refreshToken;
+    }
+}

--- a/src/main/java/com/app/demo/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/app/demo/dto/response/LoginResponseDTO.java
@@ -10,7 +10,8 @@ public class LoginResponseDTO {
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class OAuthResponse {
-        Long userId;
+        Long memberId;
+        String nickname;
         String accessToken;
         String refreshToken;
         Boolean isLogin;

--- a/src/main/java/com/app/demo/dto/response/TokenRefreshResponse.java
+++ b/src/main/java/com/app/demo/dto/response/TokenRefreshResponse.java
@@ -1,0 +1,16 @@
+package com.app.demo.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRefreshResponse {
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType = "Bearer";
+    private Long expiresIn; // 액세스 토큰의 만료 시간을 초 단위로 설정
+
+}

--- a/src/main/java/com/app/demo/security/filter/AuthExceptionHandlingFilter.java
+++ b/src/main/java/com/app/demo/security/filter/AuthExceptionHandlingFilter.java
@@ -1,0 +1,41 @@
+package com.app.demo.security.filter;
+
+import java.io.IOException;
+
+import com.app.demo.apiPayload.BaseResponse;
+import com.app.demo.apiPayload.code.status.ErrorStatus;
+import com.app.demo.apiPayload.exception.AuthException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class AuthExceptionHandlingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AuthException e) {
+            response.setContentType("application/json; charset=UTF-8");
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+            ErrorStatus code = (ErrorStatus) e.getCode();
+
+            BaseResponse<Object> errorResponse =
+                    BaseResponse.onFailure(code.getCode(), code.getMessage(), null);
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.writeValue(response.getOutputStream(), errorResponse);
+        }
+    }
+}

--- a/src/main/java/com/app/demo/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/app/demo/security/filter/JwtRequestFilter.java
@@ -1,0 +1,62 @@
+package com.app.demo.security.filter;
+
+import java.io.IOException;
+
+import com.app.demo.apiPayload.code.status.ErrorStatus;
+import com.app.demo.apiPayload.exception.AuthException;
+import com.app.demo.security.principal.PrincipalDetailsService;
+import com.app.demo.security.provider.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Component
+@RequiredArgsConstructor
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PrincipalDetailsService principalDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring("Bearer ".length());
+
+            try {
+                if (jwtTokenProvider.validateToken(token)) {
+                    String userId = jwtTokenProvider.getSubjectFromToken(token);
+                    UserDetails userDetails = principalDetailsService.loadUserByUsername(userId);
+
+                    if (userDetails != null) {
+                        UsernamePasswordAuthenticationToken authentication =
+                                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                    }
+                }
+            } catch (Exception e) {
+                // 일반적으로 여기서 응답을 조작하여 HTTP 상태 코드를 설정
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Unauthorized: " + e.getMessage());
+                return; // 추가 필터 처리 중단
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/app/demo/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/app/demo/security/filter/JwtRequestFilter.java
@@ -36,7 +36,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         String authorizationHeader = request.getHeader("Authorization");
 
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            String token = authorizationHeader.substring("Bearer ".length());
+            String token = authorizationHeader.substring(7);
 
             try {
                 if (jwtTokenProvider.validateToken(token)) {

--- a/src/main/java/com/app/demo/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/app/demo/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.app.demo.security.handler;
+
+import java.io.IOException;
+
+import com.app.demo.apiPayload.BaseResponse;
+import com.app.demo.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(403);
+
+        BaseResponse<Object> errorResponse =
+                BaseResponse.onFailure(
+                        ErrorStatus._FORBIDDEN.getCode(),
+                        ErrorStatus._FORBIDDEN.getMessage(),
+                        null);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/app/demo/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/app/demo/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.app.demo.security.handler;
+
+import java.io.IOException;
+
+import com.app.demo.apiPayload.BaseResponse;
+import com.app.demo.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException)
+            throws IOException, ServletException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(401);
+
+        BaseResponse<Object> errorResponse =
+                BaseResponse.onFailure(
+                        ErrorStatus._UNAUTHORIZED.getCode(),
+                        ErrorStatus._UNAUTHORIZED.getMessage(),
+                        null);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/app/demo/security/handler/annotation/ExtractToken.java
+++ b/src/main/java/com/app/demo/security/handler/annotation/ExtractToken.java
@@ -1,0 +1,10 @@
+package com.app.demo.security.handler.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface ExtractToken {}

--- a/src/main/java/com/app/demo/security/handler/resolver/ExtractTokenArgumentResolver.java
+++ b/src/main/java/com/app/demo/security/handler/resolver/ExtractTokenArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.app.demo.security.handler.resolver;
+
+import com.app.demo.security.provider.JwtTokenProvider;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ExtractTokenArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(String.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory)
+            throws Exception {
+
+        String refreshToken = webRequest.getHeader("Authorization");
+        jwtTokenProvider.validateToken(refreshToken);
+        return refreshToken;
+    }
+}

--- a/src/main/java/com/app/demo/security/handler/resolver/ExtractTokenArgumentResolver.java
+++ b/src/main/java/com/app/demo/security/handler/resolver/ExtractTokenArgumentResolver.java
@@ -31,7 +31,7 @@ public class ExtractTokenArgumentResolver implements HandlerMethodArgumentResolv
             throws Exception {
 
         String refreshToken = webRequest.getHeader("Authorization");
-        jwtTokenProvider.validateToken(refreshToken);
+        jwtTokenProvider.validateToken(refreshToken.substring(7));
         return refreshToken;
     }
 }

--- a/src/main/java/com/app/demo/security/principal/PrincipalDetails.java
+++ b/src/main/java/com/app/demo/security/principal/PrincipalDetails.java
@@ -1,0 +1,62 @@
+package com.app.demo.security.principal;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.app.demo.entity.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PrincipalDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_USER");
+
+        return roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getMemberId().toString();
+    }
+
+    public String getUserID() {
+        return member.getUserID();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/app/demo/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/app/demo/security/principal/PrincipalDetailsService.java
@@ -20,10 +20,10 @@ public class PrincipalDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String userMemberId) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
         Member member =
                 memberRepository
-                        .findById(Long.parseLong(userMemberId))
+                        .findByUserID(userId)
                         .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND));
 
         return new PrincipalDetails(member);

--- a/src/main/java/com/app/demo/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/app/demo/security/principal/PrincipalDetailsService.java
@@ -1,0 +1,31 @@
+package com.app.demo.security.principal;
+
+import com.app.demo.apiPayload.code.status.ErrorStatus;
+import com.app.demo.apiPayload.exception.AuthException;
+import com.app.demo.entity.Member;
+import com.app.demo.repository.MemberRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userMemberId) throws UsernameNotFoundException {
+        Member member =
+                memberRepository
+                        .findById(Long.parseLong(userMemberId))
+                        .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND));
+
+        return new PrincipalDetails(member);
+    }
+}

--- a/src/main/java/com/app/demo/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/app/demo/security/provider/JwtTokenProvider.java
@@ -1,0 +1,139 @@
+package com.app.demo.security.provider;
+
+import com.app.demo.dto.response.LoginResponseDTO;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey,
+                            @Value("${jwt.accessTokenValidityInMilliseconds}") long accessTokenValidityInMilliseconds,
+                            @Value("${jwt.refreshTokenValidityInMilliseconds}") long refreshTokenValidityInMilliseconds) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenValidityInMilliseconds = accessTokenValidityInMilliseconds;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInMilliseconds;
+    }
+
+    public LoginResponseDTO.JwtToken generateToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = System.currentTimeMillis();
+        Date accessTokenExpiresIn = new Date(now + accessTokenValidityInMilliseconds);
+        Date refreshTokenExpiresIn = new Date(now + refreshTokenValidityInMilliseconds);
+
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .setExpiration(refreshTokenExpiresIn)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        return LoginResponseDTO.JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
+    public Authentication getAuthentication(String accessToken) {
+        // Jwt 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get("auth").toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication return
+        // UserDetails: interface, User: UserDetails를 구현한 class
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // 토큰 정보를 검증하는 메서드
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+
+    // accessToken
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    // Refresh Token 처리
+    public String getSubjectFromToken(String refreshToken) {
+        Claims claims = parseClaims(refreshToken);
+        return claims.getSubject();
+    }
+
+    public long getRemainingTime(String token) {
+        Claims claims = parseClaims(token);
+        long expirationTime = claims.getExpiration().getTime();
+        long currentTime = System.currentTimeMillis();
+        return (expirationTime - currentTime) / 1000;  // 초 단위로 반환
+    }
+
+}

--- a/src/main/java/com/app/demo/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/app/demo/security/provider/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.app.demo.security.provider;
 import com.app.demo.dto.response.LoginResponseDTO;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.DecodingException;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -76,6 +77,9 @@ public class JwtTokenProvider {
 
         if (claims.get("auth") == null) {
             throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        } else {
+            // 로그 출력을 추가하여 어떤 값이 실제로 반환되는지 확인
+            log.debug("User ID from token: {}", claims.getSubject());
         }
 
         // 클레임에서 권한 정보 가져오기
@@ -91,6 +95,7 @@ public class JwtTokenProvider {
 
     // 토큰 정보를 검증하는 메서드
     public boolean validateToken(String token) {
+        log.debug("Validating token: {}", token);
         try {
             Jwts.parserBuilder()
                     .setSigningKey(secretKey)
@@ -105,6 +110,8 @@ public class JwtTokenProvider {
             log.info("Unsupported JWT Token", e);
         } catch (IllegalArgumentException e) {
             log.info("JWT claims string is empty.", e);
+        } catch (DecodingException e){
+            log.error("Token validation error: {}", e.getMessage());
         }
         return false;
     }

--- a/src/main/java/com/app/demo/service/MemberService.java
+++ b/src/main/java/com/app/demo/service/MemberService.java
@@ -9,7 +9,7 @@ import com.app.demo.entity.Member;
 public interface MemberService {
     Member findUserById(Long userId);
     public Member signUp(MemberSignupDTO memberSignUpDto) throws Exception;
-    public LoginResponseDTO.JwtToken login (LoginRequestDTO loginRequestDTO);
+    public LoginResponseDTO.OAuthResponse login (LoginRequestDTO loginRequestDTO);
     void deleteMember(Member member);
     public TokenRefreshResponse refresh(String refreshToken);
 }

--- a/src/main/java/com/app/demo/service/MemberService.java
+++ b/src/main/java/com/app/demo/service/MemberService.java
@@ -1,10 +1,15 @@
 package com.app.demo.service;
 
 import com.app.demo.dto.MemberSignupDTO;
+import com.app.demo.dto.request.LoginRequestDTO;
+import com.app.demo.dto.response.LoginResponseDTO;
+import com.app.demo.dto.response.TokenRefreshResponse;
 import com.app.demo.entity.Member;
 
 public interface MemberService {
     Member findUserById(Long userId);
     public Member signUp(MemberSignupDTO memberSignUpDto) throws Exception;
+    public LoginResponseDTO.JwtToken login (LoginRequestDTO loginRequestDTO);
     void deleteMember(Member member);
+    public TokenRefreshResponse refresh(String refreshToken);
 }

--- a/src/main/java/com/app/demo/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.app.demo.service.impl;
 import com.app.demo.apiPayload.code.status.ErrorStatus;
 import com.app.demo.apiPayload.exception.AuthException;
 import com.app.demo.apiPayload.exception.UserException;
+import com.app.demo.converter.MemberConverter;
 import com.app.demo.dto.MemberSignupDTO;
 import com.app.demo.dto.request.LoginRequestDTO;
 import com.app.demo.dto.response.LoginResponseDTO;
@@ -32,12 +33,12 @@ import java.util.Arrays;
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final MemberConverter memberConverter;
     private final JwtTokenProvider jwtTokenProvider;
     @Override
-    public Member findUserById(Long userId) {
+    public Member findUserById(Long memberId) {
         return memberRepository
-                .findById(userId)
+                .findById(memberId)
                 .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
     }
     @Override
@@ -60,7 +61,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public LoginResponseDTO.JwtToken login(LoginRequestDTO loginRequestDTO) {
+    public LoginResponseDTO.OAuthResponse login(LoginRequestDTO loginRequestDTO) {
         // 사용자 ID로 멤버 조회
         Member member = memberRepository.findByUserID(loginRequestDTO.getUserID())
                 .orElseThrow(() -> new RuntimeException("User not found.")); // 예외 처리 강화 필요
@@ -82,7 +83,7 @@ public class MemberServiceImpl implements MemberService {
         memberRepository.save(member);
 
         // 토큰 반환
-        return jwtToken;
+        return memberConverter.convertToOAuthResponse(member, jwtToken.getAccessToken(), jwtToken.getRefreshToken());
     }
 
     // 토큰 새로 고침 로직

--- a/src/main/java/com/app/demo/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/MemberServiceImpl.java
@@ -1,17 +1,29 @@
 package com.app.demo.service.impl;
 
 import com.app.demo.apiPayload.code.status.ErrorStatus;
+import com.app.demo.apiPayload.exception.AuthException;
 import com.app.demo.apiPayload.exception.UserException;
 import com.app.demo.dto.MemberSignupDTO;
+import com.app.demo.dto.request.LoginRequestDTO;
+import com.app.demo.dto.response.LoginResponseDTO;
+import com.app.demo.dto.response.TokenRefreshResponse;
 import com.app.demo.entity.Member;
 import com.app.demo.repository.MemberRepository;
+import com.app.demo.security.provider.JwtTokenProvider;
 import com.app.demo.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
 
 @Service
 @Transactional(readOnly = true)
@@ -20,6 +32,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
     @Override
     public Member findUserById(Long userId) {
         return memberRepository
@@ -44,6 +58,59 @@ public class MemberServiceImpl implements MemberService {
         return member;
     }
 
+    @Override
+    @Transactional
+    public LoginResponseDTO.JwtToken login(LoginRequestDTO loginRequestDTO) {
+        // 사용자 ID로 멤버 조회
+        Member member = memberRepository.findByUserID(loginRequestDTO.getUserID())
+                .orElseThrow(() -> new RuntimeException("User not found.")); // 예외 처리 강화 필요
+
+        // 패스워드 검증
+        if (!passwordEncoder.matches(loginRequestDTO.getPassword(), member.getPassword())) {
+            throw new RuntimeException("Invalid password."); // 예외 처리 강화 필요
+        }
+
+        // 사용자 인증 정보 생성
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                member.getUserID(), null, Arrays.asList(new SimpleGrantedAuthority("USER")));
+
+        // JWT 토큰 생성
+        LoginResponseDTO.JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
+
+        // 리프레시 토큰 업데이트 및 저장
+        member.setRefreshToken(jwtToken.getRefreshToken());
+        memberRepository.save(member);
+
+        // 토큰 반환
+        return jwtToken;
+    }
+
+    // 토큰 새로 고침 로직
+    @Transactional
+    @Override
+    public TokenRefreshResponse refresh(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("Invalid refresh token.");
+        }
+
+        String userId = jwtTokenProvider.getSubjectFromToken(refreshToken);
+        Member member = memberRepository.findByUserID(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + userId));
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                member.getUserID(), null, Arrays.asList(new SimpleGrantedAuthority("USER")));
+
+        LoginResponseDTO.JwtToken newTokens = jwtTokenProvider.generateToken(authentication);
+        long expiresIn = jwtTokenProvider.getRemainingTime(newTokens.getAccessToken());
+
+        member.setRefreshToken(newTokens.getRefreshToken());
+        memberRepository.save(member);
+
+        return new TokenRefreshResponse(newTokens.getAccessToken(), newTokens.getRefreshToken(), "Bearer", expiresIn);
+    }
+
+
+    // 회원 삭제 로직
     @Transactional
     public void deleteMember(Member member) {
         memberRepository.delete(member);

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,0 +1,4 @@
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  accessTokenValidityInMilliseconds: ${JWT_ACCESS_TOKEN_TIME}
+  refreshTokenValidityInMilliseconds: ${JWT_REFRESH_TOKEN_TIME}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #28 

## 📌 개요
- 로그인 API 구현

## 🔁 변경 사항

## 📸 스크린샷

<login API>

![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/462d457f-ad96-440a-8333-894445ec6b44)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/48a6a876-430a-4497-8b26-5e6737a6bbb6)
<refresh token 발급 API>
accessToken을 Authorize에 입력합니다.
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/d1b95b29-791b-400f-8934-284398ada777)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/43d2aff8-b1ba-4eb5-8077-2ea08e01f15b)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/c0d31b65-6d4d-4f7c-81b5-1cce1b962831)



## 👀 기타 더 이야기해볼 점

Diary 부분 API에서 수정사항 있습니다.
1. response부분에는 member 부분하고 memberId는 필요 없을 것 같아서 삭제하는 게 response도 깔끔하고 좋을 것 같습니다! diaryId는 유니크 하기 때문에 memberId에 따라 id가 달라지지 않아서요! 
2. aiemotion은 리스트 숫자값으로 변경해야할 것 같습니다! 저희 그래프를 위한 값들을 저장하니까요! enum 삭제하고요
3. 제 로그인 API 구현하면서 찾은 게 일기 조회 API 문제입니다. 이는 전에 말씀드렸던 Fetch 관련 문제예요. Fetch.LAZY에 대한 문제거든요. member 관련된 정보가 로딩이 다 안된채로 응답이 나가서 생기는 문제입니다. 그래서 fetchType을 EAGER로 변경시에는 api가 제대로 되지만, EAGER 사용시 성능 저하 등 위험하기 때문에 "FetchType.LAZY로 유지하고, 필요한 곳에서만 fetch join을 사용하여 최적화" 방법을 사용해야 합니다. 이 부분도 가능하시다면 수정 부탁드립니다.

이슈 파서 수정 부탁드립니다! 

- 로그인 시 application-jwt.yml 참고하셔서 환경변수 설정하여야 합니다!

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
