### PR TITLE
✨ [feat]: getPlaylist API 구현

### DIFF
--- a/src/main/java/com/app/demo/controller/AIPlaylistController.java
+++ b/src/main/java/com/app/demo/controller/AIPlaylistController.java
@@ -33,9 +33,9 @@ public class AIPlaylistController {
     @ResponseStatus(code = HttpStatus.OK)
     @Operation(summary = "AI플레이리스트음악조회", description = "AI플레이리스트 내 음악 조회 API입니다")
     @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
-    @GetMapping("/details/{aiPlaylistID}")
-    public BaseResponse<AIPlaylistResponseDTO.AIPlaylistMusicsDTO> getAIPlaylistMusics(@PathVariable Long aiPlaylistId){
-        AIPlaylist aiPlaylist = aiPlaylistService.getAIPlaylist(aiPlaylistId);
+    @GetMapping("/details/{diaryId}")
+    public BaseResponse<AIPlaylistResponseDTO.AIPlaylistMusicsDTO> getAIPlaylistMusics(@PathVariable Long diaryId){
+        AIPlaylist aiPlaylist = aiPlaylistService.getAIPlaylistByDiaryId(diaryId);
         AIPlaylistConverter converter = new AIPlaylistConverter(aiPlaylistMusicRepository, musicRepository);
         AIPlaylistResponseDTO.AIPlaylistMusicsDTO responseDTO = converter.toAIPlaylistMusics(aiPlaylist);
         return BaseResponse.onSuccess(responseDTO);

--- a/src/main/java/com/app/demo/controller/AIPlaylistController.java
+++ b/src/main/java/com/app/demo/controller/AIPlaylistController.java
@@ -1,0 +1,45 @@
+package com.app.demo.controller;
+import com.app.demo.apiPayload.BaseResponse;
+import com.app.demo.converter.AIPlaylistConverter;
+import com.app.demo.dto.response.AIPlaylistResponseDTO;
+import com.app.demo.entity.AIPlaylist;
+import com.app.demo.repository.AIPlaylistMusicRepository;
+import com.app.demo.repository.MusicRepository;
+import com.app.demo.service.AIPlaylistService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/AIPlaylist")
+public class AIPlaylistController {
+
+    private final AIPlaylistService aiPlaylistService;
+    private final AIPlaylistMusicRepository aiPlaylistMusicRepository;
+    private final MusicRepository musicRepository;
+
+    @Autowired
+    public AIPlaylistController(AIPlaylistService aiPlaylistService,
+                                AIPlaylistMusicRepository aiPlaylistMusicRepository,
+                                MusicRepository musicRepository) {
+        this.aiPlaylistService = aiPlaylistService;
+        this.aiPlaylistMusicRepository = aiPlaylistMusicRepository;
+        this.musicRepository = musicRepository;
+    }
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "AI플레이리스트음악조회", description = "AI플레이리스트 내 음악 조회 API입니다")
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
+    @GetMapping("/details/{aiPlaylistID}")
+    public BaseResponse<AIPlaylistResponseDTO.AIPlaylistMusicsDTO> getAIPlaylistMusics(@PathVariable Long aiPlaylistId){
+        AIPlaylist aiPlaylist = aiPlaylistService.getAIPlaylist(aiPlaylistId);
+        AIPlaylistConverter converter = new AIPlaylistConverter(aiPlaylistMusicRepository, musicRepository);
+        AIPlaylistResponseDTO.AIPlaylistMusicsDTO responseDTO = converter.toAIPlaylistMusics(aiPlaylist);
+        return BaseResponse.onSuccess(responseDTO);
+    }
+
+
+}

--- a/src/main/java/com/app/demo/controller/AIPlaylistController.java
+++ b/src/main/java/com/app/demo/controller/AIPlaylistController.java
@@ -24,7 +24,6 @@ public class AIPlaylistController {
     private final AIPlaylistService aiPlaylistService;
     private final AIPlaylistMusicRepository aiPlaylistMusicRepository;
     private final MusicRepository musicRepository;
-
     private final DiaryRepository diaryRepository;
 
 
@@ -43,10 +42,26 @@ public class AIPlaylistController {
     @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
     @GetMapping("/details/{diaryId}")
     public BaseResponse<AIPlaylistResponseDTO.AIPlaylistMusicsDTO> getAIPlaylistMusics(@PathVariable Long diaryId){
-        AIPlaylist aiPlaylist = diaryRepository.findByDiaryId(diaryId).getAiPlaylist();
+        AIPlaylist aiPlaylist = aiPlaylistService.getAiPlaylist(diaryId);
         AIPlaylistConverter converter = new AIPlaylistConverter(aiPlaylistMusicRepository, musicRepository);
         AIPlaylistResponseDTO.AIPlaylistMusicsDTO responseDTO = converter.toAIPlaylistMusics(aiPlaylist);
         return BaseResponse.onSuccess(responseDTO);
     }
+
+
+
+    /*
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "AI플레이리스트 테스트조회", description = "AI플레이리스트 테스트 API입니다")
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
+    @GetMapping("/test/{diaryId}")
+    public BaseResponse<AIPlaylistResponseDTO.TestDTO> getAiTest(@PathVariable Long diaryId){
+        AIPlaylist aiPlaylist = diaryRepository.findByDiaryId(diaryId).getAiPlaylist();
+        AIPlaylistConverter converter = new AIPlaylistConverter(aiPlaylistMusicRepository, musicRepository);
+        AIPlaylistResponseDTO.TestDTO responseDTO = converter.toAITest(aiPlaylist);
+        return BaseResponse.onSuccess(responseDTO);
+    }
+    */
+
 
 }

--- a/src/main/java/com/app/demo/controller/AIPlaylistController.java
+++ b/src/main/java/com/app/demo/controller/AIPlaylistController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/aiPlaylist")
+@RequestMapping("/api/aiplaylist")
 public class AIPlaylistController {
 
     private final AIPlaylistService aiPlaylistService;

--- a/src/main/java/com/app/demo/controller/AIPlaylistController.java
+++ b/src/main/java/com/app/demo/controller/AIPlaylistController.java
@@ -3,7 +3,9 @@ import com.app.demo.apiPayload.BaseResponse;
 import com.app.demo.converter.AIPlaylistConverter;
 import com.app.demo.dto.response.AIPlaylistResponseDTO;
 import com.app.demo.entity.AIPlaylist;
+import com.app.demo.entity.Diary;
 import com.app.demo.repository.AIPlaylistMusicRepository;
+import com.app.demo.repository.DiaryRepository;
 import com.app.demo.repository.MusicRepository;
 import com.app.demo.service.AIPlaylistService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/AIPlaylist")
 public class AIPlaylistController {
@@ -21,13 +25,17 @@ public class AIPlaylistController {
     private final AIPlaylistMusicRepository aiPlaylistMusicRepository;
     private final MusicRepository musicRepository;
 
+    private final DiaryRepository diaryRepository;
+
+
     @Autowired
     public AIPlaylistController(AIPlaylistService aiPlaylistService,
                                 AIPlaylistMusicRepository aiPlaylistMusicRepository,
-                                MusicRepository musicRepository) {
+                                MusicRepository musicRepository, DiaryRepository diaryRepository) {
         this.aiPlaylistService = aiPlaylistService;
         this.aiPlaylistMusicRepository = aiPlaylistMusicRepository;
         this.musicRepository = musicRepository;
+        this.diaryRepository = diaryRepository;
     }
 
     @ResponseStatus(code = HttpStatus.OK)
@@ -35,11 +43,10 @@ public class AIPlaylistController {
     @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
     @GetMapping("/details/{diaryId}")
     public BaseResponse<AIPlaylistResponseDTO.AIPlaylistMusicsDTO> getAIPlaylistMusics(@PathVariable Long diaryId){
-        AIPlaylist aiPlaylist = aiPlaylistService.getAIPlaylistByDiaryId(diaryId);
+        AIPlaylist aiPlaylist = diaryRepository.findByDiaryId(diaryId).getAiPlaylist();
         AIPlaylistConverter converter = new AIPlaylistConverter(aiPlaylistMusicRepository, musicRepository);
         AIPlaylistResponseDTO.AIPlaylistMusicsDTO responseDTO = converter.toAIPlaylistMusics(aiPlaylist);
         return BaseResponse.onSuccess(responseDTO);
     }
-
 
 }

--- a/src/main/java/com/app/demo/controller/AIPlaylistController.java
+++ b/src/main/java/com/app/demo/controller/AIPlaylistController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/AIPlaylist")
+@RequestMapping("/api/aiPlaylist")
 public class AIPlaylistController {
 
     private final AIPlaylistService aiPlaylistService;

--- a/src/main/java/com/app/demo/controller/DiaryController.java
+++ b/src/main/java/com/app/demo/controller/DiaryController.java
@@ -109,7 +109,7 @@ public class DiaryController {
     @ResponseStatus(code = HttpStatus.OK)
     @Operation(summary = "일기조회", description = "일기조회 API입니다")
     @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
-    @PostMapping("/details/{diaryId}")
+    @GetMapping("/details/{diaryId}")
     public BaseResponse<DiaryResponseDTO.DiaryContentDTO> getDiary(@PathVariable Long diaryId){
         Diary diary = diaryService.getDiary(diaryId);
         DiaryResponseDTO.DiaryContentDTO responseDTO = DiaryConverter.toDiaryContentDTO(diary);

--- a/src/main/java/com/app/demo/controller/MemberPlaylistController.java
+++ b/src/main/java/com/app/demo/controller/MemberPlaylistController.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/memberPlaylist")
+@RequestMapping("/api/memberplaylist")
 public class MemberPlaylistController {
 
     private final MemberPlaylistService memberPlaylistService;

--- a/src/main/java/com/app/demo/controller/MemberPlaylistController.java
+++ b/src/main/java/com/app/demo/controller/MemberPlaylistController.java
@@ -1,0 +1,103 @@
+package com.app.demo.controller;
+
+
+import com.app.demo.apiPayload.BaseResponse;
+import com.app.demo.converter.MemberPlaylistInfoConverter;
+import com.app.demo.dto.response.MemberPlaylistResponseDTO;
+import com.app.demo.entity.MemberPlaylist;
+import com.app.demo.entity.Music;
+import com.app.demo.entity.enums.Emotion;
+import com.app.demo.repository.DiaryRepository;
+import com.app.demo.repository.MemberPlaylistMusicRepository;
+import com.app.demo.repository.MemberRepository;
+import com.app.demo.repository.MusicRepository;
+import com.app.demo.service.MemberPlaylistService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import com.app.demo.converter.MemberPlaylistConverter;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/memberPlaylist")
+public class MemberPlaylistController {
+
+    private final MemberPlaylistService memberPlaylistService;
+    private final MemberPlaylistMusicRepository memberPlaylistMusicRepository;
+    private final MusicRepository musicRepository;
+
+    @Autowired
+    public MemberPlaylistController(MemberPlaylistService memberPlaylistService, MemberPlaylistMusicRepository memberPlaylistMusicRepository, MusicRepository musicRepository){
+        this.musicRepository=musicRepository;
+        this.memberPlaylistService=memberPlaylistService;
+        this.memberPlaylistMusicRepository=memberPlaylistMusicRepository;
+    }
+
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "Member 날짜음악조회", description = "Member플리 날짜로 검색하여 음악 조회 API입니다")
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
+    @GetMapping("/details1/{memberId}/{playlistDate}")
+    public BaseResponse<MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO> getMemberPlaylistMusicsByDate(@PathVariable Long memberId, @PathVariable LocalDate playlistDate){
+        MemberPlaylist memberPlaylist = memberPlaylistService.getMemberPlaylistByDate(memberId, playlistDate);
+        MemberPlaylistConverter memberPlaylistConverter = new MemberPlaylistConverter(musicRepository, memberPlaylistMusicRepository);
+        MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO memberPlaylistMusicsDTO = memberPlaylistConverter.toMemberPlaylistMusics(memberPlaylist);
+        return BaseResponse.onSuccess(memberPlaylistMusicsDTO);
+    }
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "Member 감정음악조회", description = "Member플리 감정으로 검색하여 음악 조회 API입니다")
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
+    @GetMapping("/details2/{memberId}/{memberEmotion}")
+    public BaseResponse<MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO> getMemberPlaylistMusicsByEmotion(@PathVariable Long memberId, @PathVariable Emotion memberEmotion){
+        List<MemberPlaylist> memberPlaylistList = memberPlaylistService.getMemberPlaylistListByEmotion(memberId, memberEmotion);
+        MemberPlaylistConverter memberPlaylistConverter = new MemberPlaylistConverter(musicRepository, memberPlaylistMusicRepository);
+        MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO memberPlaylistMusicsDTO = memberPlaylistConverter.toMemberPlaylistListMusics(memberPlaylistList);
+        return BaseResponse.onSuccess(memberPlaylistMusicsDTO);
+    }
+
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "MemberPlaylistInfo", description = "MemberPlaylist의 간단한 정보를 얻는 API입니다")
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
+    @GetMapping("/info/{memberId}")
+    public BaseResponse<List<MemberPlaylistResponseDTO.MemberPlaylistInfoDTO>> getMemberPlaylistInfo(@PathVariable Long memberId){
+        List<MemberPlaylist> memberPlaylistList = memberPlaylistService.getMemberPlaylistListByMemberId(memberId);
+        return BaseResponse.onSuccess(MemberPlaylistInfoConverter.toMemberPlaylistInfo(memberPlaylistList));
+    }
+
+
+
+    /*
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "test", description = "MemberPlaylist_date의 test API입니다")
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
+    @GetMapping("/test/{memberId}/{playlistDate}")
+    public BaseResponse<MemberPlaylistResponseDTO.TestDTO> getDateTest(@PathVariable Long memberId, @PathVariable LocalDate playlistDate){
+        MemberPlaylist memberPlaylist = memberPlaylistService.getMemberPlaylistByDate(memberId,playlistDate);
+        MemberPlaylistConverter memberPlaylistConverter = new MemberPlaylistConverter(musicRepository, memberPlaylistMusicRepository);
+        MemberPlaylistResponseDTO.TestDTO testDTO = memberPlaylistConverter.toTestDateDTO(memberPlaylist);
+        return BaseResponse.onSuccess(testDTO);
+    }
+
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "test2", description = "MemberPlaylist_emotion의 test API입니다")
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
+    @GetMapping("/test2/{memberId}/{memberEmotion}")
+    public BaseResponse<List<MemberPlaylistResponseDTO.TestDTO>> getEmotionTest(@PathVariable Long memberId, @PathVariable Emotion memberEmotion){
+        List<MemberPlaylist> memberPlaylist = memberPlaylistService.getMemberPlaylistListByEmotion(memberId,memberEmotion);
+        MemberPlaylistConverter memberPlaylistConverter = new MemberPlaylistConverter(musicRepository, memberPlaylistMusicRepository);
+        List<MemberPlaylistResponseDTO.TestDTO> testDTOS = memberPlaylistConverter.toTestEmoDTO(memberPlaylist);
+        return BaseResponse.onSuccess(testDTOS);
+    }
+    */
+
+
+
+}

--- a/src/main/java/com/app/demo/controller/MemberPreferenceController.java
+++ b/src/main/java/com/app/demo/controller/MemberPreferenceController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 
 @RestController
-@RequestMapping("/api/memberPreference")
+@RequestMapping("/api/memberpreference")
 public class MemberPreferenceController {
     @Autowired
     private final MemberPreferenceService memberPreferenceService;

--- a/src/main/java/com/app/demo/converter/AIPlaylistConverter.java
+++ b/src/main/java/com/app/demo/converter/AIPlaylistConverter.java
@@ -30,7 +30,7 @@ public class AIPlaylistConverter {
             musicRepository.findById(musicId).ifPresent(aiPlaylistMusics::add);
         }
         return AIPlaylistResponseDTO.AIPlaylistMusicsDTO.builder()
-                .AIPlaylistMusics(aiPlaylistMusics)
+                .aiPlaylistMusics(aiPlaylistMusics)
                 .build();
     }
 

--- a/src/main/java/com/app/demo/converter/AIPlaylistConverter.java
+++ b/src/main/java/com/app/demo/converter/AIPlaylistConverter.java
@@ -22,7 +22,7 @@ public class AIPlaylistConverter {
     }
 
     public AIPlaylistResponseDTO.AIPlaylistMusicsDTO toAIPlaylistMusics(AIPlaylist aiPlaylist){
-        Long aiPlaylistId = aiPlaylist.getId();
+        Long aiPlaylistId = aiPlaylist.getAiPlaylistId();
         List<AIPlaylistMusic> aiPlaylistMusicList = aiPlaylistMusicRepository.findByAiPlaylistId(aiPlaylistId);
         List<Music> aiPlaylistMusics = new ArrayList<>();
         for(AIPlaylistMusic aiPlaylistMusic : aiPlaylistMusicList){

--- a/src/main/java/com/app/demo/converter/AIPlaylistConverter.java
+++ b/src/main/java/com/app/demo/converter/AIPlaylistConverter.java
@@ -3,11 +3,13 @@ package com.app.demo.converter;
 import com.app.demo.dto.response.AIPlaylistResponseDTO;
 import com.app.demo.entity.AIPlaylist;
 import com.app.demo.entity.Music;
+import com.app.demo.entity.enums.Emotion;
 import com.app.demo.entity.mapping.AIPlaylistMusic;
 import com.app.demo.repository.AIPlaylistMusicRepository;
 import com.app.demo.repository.MusicRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,6 +33,15 @@ public class AIPlaylistConverter {
         }
         return AIPlaylistResponseDTO.AIPlaylistMusicsDTO.builder()
                 .aiPlaylistMusics(aiPlaylistMusics)
+                .build();
+    }
+
+    public AIPlaylistResponseDTO.TestDTO toAITest(AIPlaylist aiPlaylist){
+        return AIPlaylistResponseDTO.TestDTO.builder()
+                .playlistDate(aiPlaylist.getPlaylistDate())
+                .aiEmotion(aiPlaylist.getAiEmotion())
+                .diaryId(aiPlaylist.getDiaryId())
+                .memberId(aiPlaylist.getMemberId())
                 .build();
     }
 

--- a/src/main/java/com/app/demo/converter/AIPlaylistConverter.java
+++ b/src/main/java/com/app/demo/converter/AIPlaylistConverter.java
@@ -1,0 +1,37 @@
+package com.app.demo.converter;
+
+import com.app.demo.dto.response.AIPlaylistResponseDTO;
+import com.app.demo.entity.AIPlaylist;
+import com.app.demo.entity.Music;
+import com.app.demo.entity.mapping.AIPlaylistMusic;
+import com.app.demo.repository.AIPlaylistMusicRepository;
+import com.app.demo.repository.MusicRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AIPlaylistConverter {
+    private final AIPlaylistMusicRepository aiPlaylistMusicRepository;
+    private final MusicRepository musicRepository;
+
+    @Autowired
+    public AIPlaylistConverter(AIPlaylistMusicRepository aiPlaylistMusicRepository, MusicRepository musicRepository) {
+        this.aiPlaylistMusicRepository = aiPlaylistMusicRepository;
+        this.musicRepository = musicRepository;
+    }
+
+    public AIPlaylistResponseDTO.AIPlaylistMusicsDTO toAIPlaylistMusics(AIPlaylist aiPlaylist){
+        Long aiPlaylistId = aiPlaylist.getId();
+        List<AIPlaylistMusic> aiPlaylistMusicList = aiPlaylistMusicRepository.findByAiPlaylistId(aiPlaylistId);
+        List<Music> aiPlaylistMusics = new ArrayList<>();
+        for(AIPlaylistMusic aiPlaylistMusic : aiPlaylistMusicList){
+            Long musicId = aiPlaylistMusic.getId();
+            musicRepository.findById(musicId).ifPresent(aiPlaylistMusics::add);
+        }
+        return AIPlaylistResponseDTO.AIPlaylistMusicsDTO.builder()
+                .AIPlaylistMusics(aiPlaylistMusics)
+                .build();
+    }
+
+}

--- a/src/main/java/com/app/demo/converter/DiaryConverter.java
+++ b/src/main/java/com/app/demo/converter/DiaryConverter.java
@@ -20,7 +20,7 @@ public class DiaryConverter {
                 .content(diary.getContent())
                 .pictureKey(diary.getPictureKey())
                 .aiPlaylistId(diary.getAiPlaylist().getAiPlaylistId())
-                .memberPlaylistId(diary.getMemberPlaylist().getId())
+                .memberPlaylistId(diary.getMemberPlaylist().getMemberPlaylistId())
                 .writtenDate(diary.getWrittenDate())
                 .build();
     }

--- a/src/main/java/com/app/demo/converter/DiaryConverter.java
+++ b/src/main/java/com/app/demo/converter/DiaryConverter.java
@@ -12,7 +12,7 @@ public class DiaryConverter {
 
     public static DiaryResponseDTO.DiaryContentDTO toDiaryContentDTO(Diary diary){
         return DiaryResponseDTO.DiaryContentDTO.builder()
-                .id(diary.getId())
+                .id(diary.getDiaryId())
                 .member(diary.getMember())
                 .memberId(diary.getMemberId())
                 .AIEmotion(diary.getAiEmotion())
@@ -26,7 +26,7 @@ public class DiaryConverter {
     }
     public static DiaryResponseDTO.MonthlyDiaryDTO toMonthlyDiaryDTO(Diary diary){
         return DiaryResponseDTO.MonthlyDiaryDTO.builder()
-                .id(diary.getId())
+                .id(diary.getDiaryId())
                 .writtenDate(diary.getWrittenDate())
                 .memberEmotion(diary.getMemberEmotion())
                 .build();

--- a/src/main/java/com/app/demo/converter/DiaryConverter.java
+++ b/src/main/java/com/app/demo/converter/DiaryConverter.java
@@ -19,7 +19,7 @@ public class DiaryConverter {
                 .memberEmotion(diary.getMemberEmotion())
                 .content(diary.getContent())
                 .pictureKey(diary.getPictureKey())
-                .aiPlaylistId(diary.getAiPlaylist().getId())
+                .aiPlaylistId(diary.getAiPlaylist().getAiPlaylistId())
                 .memberPlaylistId(diary.getMemberPlaylist().getId())
                 .writtenDate(diary.getWrittenDate())
                 .build();

--- a/src/main/java/com/app/demo/converter/MemberPlaylistConverter.java
+++ b/src/main/java/com/app/demo/converter/MemberPlaylistConverter.java
@@ -1,0 +1,84 @@
+package com.app.demo.converter;
+
+import com.app.demo.dto.response.MemberPlaylistResponseDTO;
+import com.app.demo.entity.Diary;
+import com.app.demo.entity.MemberPlaylist;
+
+import com.app.demo.entity.Music;
+import com.app.demo.entity.mapping.MemberPlaylistMusic;
+import com.app.demo.repository.MusicRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.app.demo.repository.MemberPlaylistMusicRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MemberPlaylistConverter {
+
+    private final MemberPlaylistMusicRepository memberPlaylistMusicRepository;
+    private final MusicRepository musicRepository;
+
+    @Autowired
+    public MemberPlaylistConverter(MusicRepository musicRepository, MemberPlaylistMusicRepository memberPlaylistMusicRepository)
+    {
+        this.memberPlaylistMusicRepository = memberPlaylistMusicRepository;
+        this.musicRepository = musicRepository;
+    }
+
+    public MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO toMemberPlaylistMusics(MemberPlaylist memberPlaylist){
+        Long memberPlaylistId = memberPlaylist.getMemberPlaylistId();
+        List<MemberPlaylistMusic> memberPlaylistMusicList = memberPlaylistMusicRepository.findByMemberPlaylistId(memberPlaylistId);
+        List<Music> memberPlaylistMusics = new ArrayList<>();
+        for(MemberPlaylistMusic memberPlaylistMusic : memberPlaylistMusicList){
+            Long musicId = memberPlaylistMusic.getId();
+            musicRepository.findById(musicId).ifPresent(memberPlaylistMusics::add);
+        }
+        return MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO.builder()
+                .memberPlaylistMusics(memberPlaylistMusics)
+                .build();
+
+    }
+
+    public MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO toMemberPlaylistListMusics(List<MemberPlaylist> memberPlaylistList){
+        List<Long> memberPlaylistId = new ArrayList<>();
+        for(MemberPlaylist memberPlaylist : memberPlaylistList){
+            Long id = memberPlaylist.getMemberPlaylistId();
+            memberPlaylistId.add(id);
+        }
+        List<MemberPlaylistMusic> memberPlaylistMusicList = new ArrayList<>();
+        for (Long id : memberPlaylistId) {
+            memberPlaylistMusicList.addAll(memberPlaylistMusicRepository.findByMemberPlaylistId(id));
+        }
+        List<Music> memberPlaylistMusics = new ArrayList<>();
+        for(MemberPlaylistMusic memberPlaylistMusic : memberPlaylistMusicList){
+            Long musicId = memberPlaylistMusic.getId();
+            musicRepository.findById(musicId).ifPresent(memberPlaylistMusics::add);
+        }
+        return MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO.builder()
+                .memberPlaylistMusics(memberPlaylistMusics)
+                .build();
+    }
+
+    public MemberPlaylistResponseDTO.TestDTO toTestDateDTO(MemberPlaylist memberPlaylist){
+        return MemberPlaylistResponseDTO.TestDTO.builder()
+                .playlistId(memberPlaylist.getMemberPlaylistId())
+                .memberId(memberPlaylist.getMemberId())
+                .diaryId(memberPlaylist.getDiaryId())
+                .pictureKey(memberPlaylist.getDiary().getPictureKey())
+                //.diary(memberPlaylist.getDiary())
+                .build();
+    }
+
+    public List<MemberPlaylistResponseDTO.TestDTO> toTestEmoDTO(List<MemberPlaylist> memberPlaylistList){
+        List<MemberPlaylistResponseDTO.TestDTO> testDTOS = new ArrayList<>();
+        for(MemberPlaylist memberPlaylist: memberPlaylistList){
+            testDTOS.add(MemberPlaylistResponseDTO.TestDTO.builder()
+                    .playlistId(memberPlaylist.getMemberPlaylistId())
+                    .memberId(memberPlaylist.getMemberId())
+                    .diaryId(memberPlaylist.getDiaryId())
+                    .pictureKey(memberPlaylist.getDiary().getPictureKey())
+                    .build());
+        }
+        return testDTOS;
+    }
+}

--- a/src/main/java/com/app/demo/converter/MemberPlaylistInfoConverter.java
+++ b/src/main/java/com/app/demo/converter/MemberPlaylistInfoConverter.java
@@ -1,0 +1,28 @@
+package com.app.demo.converter;
+
+import com.app.demo.dto.response.MemberPlaylistResponseDTO;
+import com.app.demo.entity.Diary;
+import com.app.demo.entity.MemberPlaylist;
+import com.app.demo.repository.DiaryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MemberPlaylistInfoConverter {
+    public static List<MemberPlaylistResponseDTO.MemberPlaylistInfoDTO> toMemberPlaylistInfo(List<MemberPlaylist> memberPlaylistList){
+        List<Diary> diaryList = new ArrayList<>();
+        for(MemberPlaylist memberPlaylist : memberPlaylistList){
+            diaryList.add(memberPlaylist.getDiary());
+        }
+        List<MemberPlaylistResponseDTO.MemberPlaylistInfoDTO> infoList = new ArrayList<>();
+        for(Diary diary : diaryList){
+            infoList.add(MemberPlaylistResponseDTO.MemberPlaylistInfoDTO.builder()
+                    .memberEmotion(diary.getMemberEmotion())
+                    .playlistDate(diary.getWrittenDate())
+                    .pictureKey(diary.getPictureKey())
+                    .build());
+        }
+        return infoList;
+    }
+}

--- a/src/main/java/com/app/demo/dto/response/AIPlaylistResponseDTO.java
+++ b/src/main/java/com/app/demo/dto/response/AIPlaylistResponseDTO.java
@@ -16,7 +16,7 @@ public class AIPlaylistResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class AIPlaylistMusicsDTO{
-        private List<Music> AIPlaylistMusics;
+        private List<Music> aiPlaylistMusics;
     }
 
 }

--- a/src/main/java/com/app/demo/dto/response/AIPlaylistResponseDTO.java
+++ b/src/main/java/com/app/demo/dto/response/AIPlaylistResponseDTO.java
@@ -1,0 +1,22 @@
+package com.app.demo.dto.response;
+
+import com.app.demo.entity.Music;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class AIPlaylistResponseDTO {
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AIPlaylistMusicsDTO{
+        private List<Music> AIPlaylistMusics;
+    }
+
+}

--- a/src/main/java/com/app/demo/dto/response/MemberPlaylistResponseDTO.java
+++ b/src/main/java/com/app/demo/dto/response/MemberPlaylistResponseDTO.java
@@ -1,5 +1,6 @@
 package com.app.demo.dto.response;
 
+import com.app.demo.entity.Diary;
 import com.app.demo.entity.Music;
 import com.app.demo.entity.enums.Emotion;
 import lombok.AllArgsConstructor;
@@ -10,27 +11,35 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.util.List;
 
-public class AIPlaylistResponseDTO {
-
+public class MemberPlaylistResponseDTO {
 
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class AIPlaylistMusicsDTO{
-        private List<Music> aiPlaylistMusics;
+    public static class MemberPlaylistMusicsDTO{
+        private List<Music> memberPlaylistMusics;
     }
 
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MemberPlaylistInfoDTO{
+        private LocalDate playlistDate;
+        private String pictureKey;
+        private Emotion memberEmotion;
+    }
 
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class TestDTO{
+        private Long playlistId;
+        private String pictureKey;
         private Long memberId;
         private Long diaryId;
-        private Emotion aiEmotion;
-        private LocalDate playlistDate;
+        private Diary diary;
     }
-
 }

--- a/src/main/java/com/app/demo/entity/AIPlaylist.java
+++ b/src/main/java/com/app/demo/entity/AIPlaylist.java
@@ -20,7 +20,7 @@ public class AIPlaylist {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ai_Playlist_id")
-    private Long id;
+    private Long aiPlaylistId;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "member_id", updatable = false)

--- a/src/main/java/com/app/demo/entity/AIPlaylist.java
+++ b/src/main/java/com/app/demo/entity/AIPlaylist.java
@@ -27,8 +27,11 @@ public class AIPlaylist {
     private Member member;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "diary_id")
+    @JoinColumn(name = "diary")
     private Diary diary;
+
+    @Column(name = "diary_id")
+    private Long diaryId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "ai_emotion")

--- a/src/main/java/com/app/demo/entity/AIPlaylist.java
+++ b/src/main/java/com/app/demo/entity/AIPlaylist.java
@@ -22,9 +22,8 @@ public class AIPlaylist {
     @Column(name = "ai_Playlist_id")
     private Long aiPlaylistId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "member_id", updatable = false)
-    private Member member;
+    @Column(name = "member_id")
+    private Long memberId;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "diary")

--- a/src/main/java/com/app/demo/entity/Diary.java
+++ b/src/main/java/com/app/demo/entity/Diary.java
@@ -22,7 +22,7 @@ public class Diary {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "diary_id")
-    private Long id;
+    private Long diaryId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member")

--- a/src/main/java/com/app/demo/entity/MemberPlaylist.java
+++ b/src/main/java/com/app/demo/entity/MemberPlaylist.java
@@ -20,15 +20,17 @@ public class MemberPlaylist {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_playlist_id")
-    private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "member_id", updatable = false)
-    private Member member;
+    private Long memberPlaylistId;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "diary_id")
+    @JoinColumn(name = "diary")
     private Diary diary;
+
+    @Column(name = "diary_id")
+    private Long diaryId;
+
+    @Column(name = "member_id")
+    private Long memberId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "member_emotion")

--- a/src/main/java/com/app/demo/entity/MemberPreferencePlaylist.java
+++ b/src/main/java/com/app/demo/entity/MemberPreferencePlaylist.java
@@ -1,0 +1,29 @@
+package com.app.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "preference_playlist")
+public class MemberPreferencePlaylist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "preference_playlist_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", updatable = false)
+    private Member member;
+
+    @Column(name = "last_update_date")
+    private LocalDate lastUpdateDate;
+
+}

--- a/src/main/java/com/app/demo/entity/mapping/AIPlaylistMusic.java
+++ b/src/main/java/com/app/demo/entity/mapping/AIPlaylistMusic.java
@@ -25,8 +25,11 @@ public class AIPlaylistMusic {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ai_playlist_id")
+    @JoinColumn(name = "ai_playlist")
     private AIPlaylist aiPlaylist;
+
+    @Column(name = "ai_playlist_id")
+    private Long aiPlaylistId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/app/demo/entity/mapping/MemberPlaylistMusic.java
+++ b/src/main/java/com/app/demo/entity/mapping/MemberPlaylistMusic.java
@@ -21,8 +21,11 @@ public class MemberPlaylistMusic {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_playlist_id")
+    @JoinColumn(name = "member_playlist")
     private MemberPlaylist memberPlaylist;
+
+    @Column(name = "member_playlist_id")
+    private Long memberPlaylistId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/app/demo/repository/AIPlaylistMusicRepository.java
+++ b/src/main/java/com/app/demo/repository/AIPlaylistMusicRepository.java
@@ -1,0 +1,13 @@
+package com.app.demo.repository;
+
+import com.app.demo.entity.AIPlaylist;
+import com.app.demo.entity.mapping.AIPlaylistMusic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AIPlaylistMusicRepository extends JpaRepository<AIPlaylistMusic, Long> {
+    List<AIPlaylistMusic> findByAiPlaylistId(Long aiPlaylistId);
+}

--- a/src/main/java/com/app/demo/repository/AIPlaylistRepository.java
+++ b/src/main/java/com/app/demo/repository/AIPlaylistRepository.java
@@ -4,6 +4,8 @@ import com.app.demo.entity.AIPlaylist;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 @Repository
 public interface AIPlaylistRepository extends JpaRepository<AIPlaylist, Long> {

--- a/src/main/java/com/app/demo/repository/AIPlaylistRepository.java
+++ b/src/main/java/com/app/demo/repository/AIPlaylistRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 @Repository
 public interface AIPlaylistRepository extends JpaRepository<AIPlaylist, Long> {
+    AIPlaylist findByDiaryId(Long diaryId);
 }

--- a/src/main/java/com/app/demo/repository/DiaryRepository.java
+++ b/src/main/java/com/app/demo/repository/DiaryRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findByMemberIdAndWrittenDateBetween(Long memberId, LocalDate startDate, LocalDate endDate);
+    Diary findByDiaryId(Long diaryId);
 
 
 }

--- a/src/main/java/com/app/demo/repository/MemberPlaylistMusicRepository.java
+++ b/src/main/java/com/app/demo/repository/MemberPlaylistMusicRepository.java
@@ -1,0 +1,12 @@
+package com.app.demo.repository;
+
+import com.app.demo.entity.mapping.MemberPlaylistMusic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+
+@Repository
+public interface MemberPlaylistMusicRepository extends JpaRepository<MemberPlaylistMusic, Long> {
+    List<MemberPlaylistMusic> findByMemberPlaylistId(Long memberPlaylistId);
+}

--- a/src/main/java/com/app/demo/repository/MemberPlaylistRepository.java
+++ b/src/main/java/com/app/demo/repository/MemberPlaylistRepository.java
@@ -1,10 +1,17 @@
 package com.app.demo.repository;
 
 import com.app.demo.entity.MemberPlaylist;
+import com.app.demo.entity.enums.Emotion;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface MemberPlaylistRepository extends JpaRepository<MemberPlaylist, Long> {
+
+    MemberPlaylist findByMemberIdAndPlaylistDate(Long memberId, LocalDate playlistDate);
+    List<MemberPlaylist> findByMemberIdAndMemberEmotion(Long memberId, Emotion memberEmotion);
+    List<MemberPlaylist> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/app/demo/service/AIPlaylistService.java
+++ b/src/main/java/com/app/demo/service/AIPlaylistService.java
@@ -2,6 +2,7 @@ package com.app.demo.service;
 
 import com.app.demo.entity.AIPlaylist;
 
+import java.util.Optional;
+
 public interface AIPlaylistService {
-    AIPlaylist getAIPlaylistByDiaryId(Long diaryId);
 }

--- a/src/main/java/com/app/demo/service/AIPlaylistService.java
+++ b/src/main/java/com/app/demo/service/AIPlaylistService.java
@@ -3,5 +3,5 @@ package com.app.demo.service;
 import com.app.demo.entity.AIPlaylist;
 
 public interface AIPlaylistService {
-    AIPlaylist getAIPlaylist(Long aiPlaylistId);
+    AIPlaylist getAIPlaylistByDiaryId(Long diaryId);
 }

--- a/src/main/java/com/app/demo/service/AIPlaylistService.java
+++ b/src/main/java/com/app/demo/service/AIPlaylistService.java
@@ -5,4 +5,5 @@ import com.app.demo.entity.AIPlaylist;
 import java.util.Optional;
 
 public interface AIPlaylistService {
+    AIPlaylist getAiPlaylist(Long diaryId);
 }

--- a/src/main/java/com/app/demo/service/AIPlaylistService.java
+++ b/src/main/java/com/app/demo/service/AIPlaylistService.java
@@ -1,0 +1,7 @@
+package com.app.demo.service;
+
+import com.app.demo.entity.AIPlaylist;
+
+public interface AIPlaylistService {
+    AIPlaylist getAIPlaylist(Long aiPlaylistId);
+}

--- a/src/main/java/com/app/demo/service/MemberPlaylistService.java
+++ b/src/main/java/com/app/demo/service/MemberPlaylistService.java
@@ -1,0 +1,15 @@
+package com.app.demo.service;
+
+import com.app.demo.entity.MemberPlaylist;
+import com.app.demo.entity.enums.Emotion;
+import com.app.demo.entity.Music;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MemberPlaylistService {
+    MemberPlaylist getMemberPlaylistByDate(Long memberId, LocalDate playlistDate);
+    List<MemberPlaylist> getMemberPlaylistListByEmotion(Long memberId, Emotion memberEmotion);
+    List<MemberPlaylist> getMemberPlaylistListByMemberId(Long memberId);
+
+}

--- a/src/main/java/com/app/demo/service/impl/AIPlaylistServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/AIPlaylistServiceImpl.java
@@ -1,0 +1,22 @@
+package com.app.demo.service.impl;
+
+
+import com.app.demo.entity.AIPlaylist;
+import com.app.demo.repository.AIPlaylistRepository;
+import com.app.demo.service.AIPlaylistService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AIPlaylistServiceImpl implements AIPlaylistService {
+    private final AIPlaylistRepository aiPlaylistRepository;
+
+    @Autowired
+    public AIPlaylistServiceImpl(AIPlaylistRepository aiPlaylistRepository) {
+        this.aiPlaylistRepository = aiPlaylistRepository;
+    }
+
+    public AIPlaylist getAIPlaylist(Long aiPlaylistId) {
+        return aiPlaylistRepository.findById(aiPlaylistId).orElse(null);
+    }
+}

--- a/src/main/java/com/app/demo/service/impl/AIPlaylistServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/AIPlaylistServiceImpl.java
@@ -3,21 +3,19 @@ package com.app.demo.service.impl;
 
 import com.app.demo.entity.AIPlaylist;
 import com.app.demo.repository.AIPlaylistRepository;
+import com.app.demo.repository.DiaryRepository;
 import com.app.demo.service.AIPlaylistService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class AIPlaylistServiceImpl implements AIPlaylistService {
     private final AIPlaylistRepository aiPlaylistRepository;
-
     @Autowired
     public AIPlaylistServiceImpl(AIPlaylistRepository aiPlaylistRepository) {
         this.aiPlaylistRepository = aiPlaylistRepository;
     }
 
-    @Override
-    public AIPlaylist getAIPlaylistByDiaryId(Long diaryId) {
-        return aiPlaylistRepository.findByDiaryId(diaryId);
-    }
 }

--- a/src/main/java/com/app/demo/service/impl/AIPlaylistServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/AIPlaylistServiceImpl.java
@@ -18,4 +18,9 @@ public class AIPlaylistServiceImpl implements AIPlaylistService {
         this.aiPlaylistRepository = aiPlaylistRepository;
     }
 
+    @Override
+    public AIPlaylist getAiPlaylist(Long diaryId){
+        return aiPlaylistRepository.findByDiaryId(diaryId);
+    }
+
 }

--- a/src/main/java/com/app/demo/service/impl/AIPlaylistServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/AIPlaylistServiceImpl.java
@@ -16,7 +16,8 @@ public class AIPlaylistServiceImpl implements AIPlaylistService {
         this.aiPlaylistRepository = aiPlaylistRepository;
     }
 
-    public AIPlaylist getAIPlaylist(Long aiPlaylistId) {
-        return aiPlaylistRepository.findById(aiPlaylistId).orElse(null);
+    @Override
+    public AIPlaylist getAIPlaylistByDiaryId(Long diaryId) {
+        return aiPlaylistRepository.findByDiaryId(diaryId);
     }
 }

--- a/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
@@ -109,7 +109,7 @@ public class DiaryServiceImpl implements DiaryService {
     }
 
     public Diary getDiary(Long diaryId) {
-        return diaryRepository.findById(diaryId).orElse(null);
+        return diaryRepository.findByDiaryId(diaryId);
     }
 }
 

--- a/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
@@ -15,12 +15,14 @@ import com.app.demo.repository.MemberPlaylistRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 public class DiaryServiceImpl implements DiaryService {
     private final DiaryRepository diaryRepository;
     private final MemberRepository memberRepository;
@@ -42,11 +44,11 @@ public class DiaryServiceImpl implements DiaryService {
         Emotion aiEmotion = extractAiEmotion(requestDTO.getContent());
         //List<Long> musicList = requestDTO.getMusicList;
 
-        AIPlaylist aiPlaylist = (AIPlaylist.builder()
+        AIPlaylist aiPlaylist = AIPlaylist.builder()
                 .member(member)
                 .aiEmotion(aiEmotion)
                 .playlistDate(getLocalDate())
-                .build());
+                .build();
         MemberPlaylist memberPlaylist = MemberPlaylist.builder()
                 .member(member)
                 .memberEmotion(requestDTO.getMemberEmotion())
@@ -66,6 +68,7 @@ public class DiaryServiceImpl implements DiaryService {
                 .build();
 
         memberPlaylist.setDiary(diary);
+        aiPlaylist.setDiaryId(diary.getDiaryId());
         aiPlaylist.setDiary(diary);
         memberPlaylistRepository.save(memberPlaylist);
         aiPlaylistRepository.save(aiPlaylist);

--- a/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
@@ -45,14 +45,12 @@ public class DiaryServiceImpl implements DiaryService {
         //List<Long> musicList = requestDTO.getMusicList;
 
         AIPlaylist aiPlaylist = AIPlaylist.builder()
-                .member(member)
+                .memberId(requestDTO.getMemberId())
                 .aiEmotion(aiEmotion)
-                .playlistDate(getLocalDate())
                 .build();
         MemberPlaylist memberPlaylist = MemberPlaylist.builder()
-                .member(member)
+                .memberId(requestDTO.getMemberId())
                 .memberEmotion(requestDTO.getMemberEmotion())
-                .playlistDate(getLocalDate())
                 .build();
         //.musicList(musicList)
         Diary diary = Diary.builder()
@@ -67,22 +65,22 @@ public class DiaryServiceImpl implements DiaryService {
                 .memberPlaylist(memberPlaylist)
                 .build();
 
+        diaryRepository.save(diary);
         memberPlaylist.setDiary(diary);
-        aiPlaylist.setDiaryId(diary.getDiaryId());
+        memberPlaylist.setPlaylistDate(diary.getWrittenDate());
+        memberPlaylist.setDiaryId(diary.getDiaryId());
         aiPlaylist.setDiary(diary);
+        aiPlaylist.setPlaylistDate(diary.getWrittenDate());
+        aiPlaylist.setDiaryId(diary.getDiaryId());
         memberPlaylistRepository.save(memberPlaylist);
         aiPlaylistRepository.save(aiPlaylist);
 
-        return diaryRepository.save(diary);
+        return diary;
 
     }
 
     private Emotion extractAiEmotion(String content) {
         return Emotion.HAPPY;       //더미값
-    }
-
-    private LocalDate getLocalDate() {
-        return LocalDate.now();
     }
 
     @Override

--- a/src/main/java/com/app/demo/service/impl/MemberPlaylistServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/MemberPlaylistServiceImpl.java
@@ -1,0 +1,44 @@
+package com.app.demo.service.impl;
+
+
+import com.app.demo.entity.MemberPlaylist;
+import com.app.demo.entity.Music;
+import com.app.demo.entity.enums.Emotion;
+import com.app.demo.entity.mapping.MemberPlaylistMusic;
+import com.app.demo.repository.MemberPlaylistMusicRepository;
+import com.app.demo.repository.MemberPlaylistRepository;
+import com.app.demo.service.MemberPlaylistService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class MemberPlaylistServiceImpl implements MemberPlaylistService {
+
+    private final MemberPlaylistRepository memberPlaylistRepository;
+
+    @Autowired
+    public MemberPlaylistServiceImpl(MemberPlaylistRepository memberPlaylistRepository) {
+        this.memberPlaylistRepository = memberPlaylistRepository;
+    }
+
+    @Override
+    public MemberPlaylist getMemberPlaylistByDate(Long memberId, LocalDate playlistDate) {
+        return memberPlaylistRepository.findByMemberIdAndPlaylistDate(memberId, playlistDate);
+    }
+
+    @Override
+    public List<MemberPlaylist> getMemberPlaylistListByEmotion(Long memberId, Emotion memberEmotion) {
+        return memberPlaylistRepository.findByMemberIdAndMemberEmotion(memberId, memberEmotion);
+    }
+
+    @Override
+    public List<MemberPlaylist> getMemberPlaylistListByMemberId(Long memberId) {
+        return memberPlaylistRepository.findByMemberId(memberId);
+    }
+
+}
+


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #32

## 📌 개요
- diaryId로 AIPlaylist의 List<Music>반환
- memberId와 date로 MemberPlaylist의 List<Music>반환
- memberId와 emotion으로 MemberPlaylist의 List<Music>반환
- memberId로 MemberPlaylist의 Info(memberEmotion, playlistDate, pictureKey)반
- PreferencePlaylist는 create와 함께 제작할 예정

## 🔁 변경 사항

## 📸 스크린샷
<img width="967" alt="image" src="https://github.com/SSU-RETURN/emuda-back/assets/87259867/1f259f8f-bf86-4986-9332-bec39fdbb1ad">
<img width="961" alt="image" src="https://github.com/SSU-RETURN/emuda-back/assets/87259867/a4236b4a-0ca4-4a44-9ded-78414b714620">
<img width="955" alt="image" src="https://github.com/SSU-RETURN/emuda-back/assets/87259867/d4573f94-a057-49ff-b307-a6b628014b06">
<img width="955" alt="image" src="https://github.com/SSU-RETURN/emuda-back/assets/87259867/2ffb11fc-4ad2-4e13-9cf1-4e6339fcc67a">
<img width="956" alt="image" src="https://github.com/SSU-RETURN/emuda-back/assets/87259867/402c2114-3d21-4735-8ac6-fbe07b4a46ec">
<img width="971" alt="image" src="https://github.com/SSU-RETURN/emuda-back/assets/87259867/60d7fa7e-c4f0-4019-8dba-11a4c5f115b7">
<img width="964" alt="image" src="https://github.com/SSU-RETURN/emuda-back/assets/87259867/de78a379-7408-4084-a93a-1987d70c832e">



## 👀 기타 더 이야기해볼 점
CreatePlaylist하실 때, Diary를 다시한번 Set해줘야할거같아요
CreateDiary내에서 Diary를 set해주는게 안되는거같아요

Playlist와 MappingTable이 양방향 연결이 아니라서, 아래와 같은 매커니즘으로 List<Music>을 구현했습니다
Service-Repository를 통해 Playlist or List<Playlist>를 가져오고,
Converter내부에서 Music, PlaylistMusic의 Repository 의존성주입받고 찾아가면서 했는데
CreatePlaylist가 없어서 테스트를 못했어서 이게 잘 작동할지 모르겠습니다.
Test메소드를 만들어서 원하는 매개변수로 Playlist를 가져오는것은 잘 되는것을 확인했습니다

만약에 안된다면, Conveter 사용을 포기하고 Service에서 전부 연결시키는식으로 한번 구현해보겠습니다



## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
