### PR TITLE
:sparkles: [feat]: 회원 탈퇴 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
-src/main/resources/application.yml
-
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/app/demo/controller/MemberController.java
+++ b/src/main/java/com/app/demo/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.app.demo.dto.MemberSignupDTO;
 import com.app.demo.dto.request.LoginRequestDTO;
 import com.app.demo.dto.response.LoginResponseDTO;
 import com.app.demo.dto.response.TokenRefreshResponse;
+import com.app.demo.entity.Member;
 import com.app.demo.security.handler.annotation.ExtractToken;
 import com.app.demo.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -48,5 +49,14 @@ public class MemberController {
     public BaseResponse<TokenRefreshResponse> refresh(@ExtractToken String refreshToken) {
         TokenRefreshResponse response = memberService.refresh(refreshToken);
         return BaseResponse.onSuccess(response);
+    }
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회 성공")})
+    @Operation(summary = "회원탈퇴 API", description = "회원을 삭제합니다.")
+    @DeleteMapping("/delete")
+    public BaseResponse<String> delete(@RequestParam Long memberId) {
+        memberService.deleteMember(memberId);
+        return BaseResponse.onSuccess("회원탈퇴 성공");
     }
 }

--- a/src/main/java/com/app/demo/entity/Diary.java
+++ b/src/main/java/com/app/demo/entity/Diary.java
@@ -24,7 +24,7 @@ public class Diary {
     @Column(name = "diary_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "member")
     private Member member;
 

--- a/src/main/java/com/app/demo/entity/Member.java
+++ b/src/main/java/com/app/demo/entity/Member.java
@@ -4,6 +4,8 @@ package com.app.demo.entity;
 import com.app.demo.entity.enums.Preference;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 // import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -33,6 +35,8 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Preference preference;
 
+    @ColumnDefault("1")  //삭제시 0
+    private int isDelete;
 
     private String refreshToken; // 리프레시 토큰
 

--- a/src/main/java/com/app/demo/entity/PreferencePlaylist.java
+++ b/src/main/java/com/app/demo/entity/PreferencePlaylist.java
@@ -22,7 +22,7 @@ public class PreferencePlaylist {
     private Long id;
 
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "member_id", updatable = false)
     private Member member;
 

--- a/src/main/java/com/app/demo/entity/mapping/AIPlaylistMusic.java
+++ b/src/main/java/com/app/demo/entity/mapping/AIPlaylistMusic.java
@@ -28,7 +28,7 @@ public class AIPlaylistMusic {
     @JoinColumn(name = "ai_playlist_id")
     private AIPlaylist aiPlaylist;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/app/demo/entity/mapping/MemberPlaylistMusic.java
+++ b/src/main/java/com/app/demo/entity/mapping/MemberPlaylistMusic.java
@@ -24,7 +24,7 @@ public class MemberPlaylistMusic {
     @JoinColumn(name = "member_playlist_id")
     private MemberPlaylist memberPlaylist;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/app/demo/service/DiaryService.java
+++ b/src/main/java/com/app/demo/service/DiaryService.java
@@ -13,7 +13,5 @@ public interface DiaryService {
     Diary updateDiary(DiaryRequestDTO.UpdateDiaryRequestDTO requestDTO);
     void deleteDiary(Long diaryId);
     List<Diary> getDiariesByMonth(Long memberId, LocalDate yearMonth);
-
     Diary getDiary(Long diaryId);
-
 }

--- a/src/main/java/com/app/demo/service/MemberService.java
+++ b/src/main/java/com/app/demo/service/MemberService.java
@@ -10,6 +10,6 @@ public interface MemberService {
     Member findUserById(Long userId);
     public Member signUp(MemberSignupDTO memberSignUpDto) throws Exception;
     public LoginResponseDTO.OAuthResponse login (LoginRequestDTO loginRequestDTO);
-    void deleteMember(Member member);
+    void deleteMember(Long memberId);
     public TokenRefreshResponse refresh(String refreshToken);
 }

--- a/src/main/java/com/app/demo/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/MemberServiceImpl.java
@@ -9,6 +9,8 @@ import com.app.demo.dto.request.LoginRequestDTO;
 import com.app.demo.dto.response.LoginResponseDTO;
 import com.app.demo.dto.response.TokenRefreshResponse;
 import com.app.demo.entity.Member;
+import com.app.demo.repository.AIPlaylistRepository;
+import com.app.demo.repository.DiaryRepository;
 import com.app.demo.repository.MemberRepository;
 import com.app.demo.security.provider.JwtTokenProvider;
 import com.app.demo.service.MemberService;
@@ -67,7 +69,11 @@ public class MemberServiceImpl implements MemberService {
     public LoginResponseDTO.OAuthResponse login(LoginRequestDTO loginRequestDTO) {
         // 사용자 ID로 멤버 조회
         Member member = memberRepository.findByUserID(loginRequestDTO.getUserID())
-                .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND)); // 예외 처리 강화 필요
+                .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND));
+
+        // 회원 존재 여부 검증
+        if(member.getIsDelete()==0)
+            throw new AuthException(ErrorStatus.USER_NOT_FOUND);
 
         // 패스워드 검증
         if (!passwordEncoder.matches(loginRequestDTO.getPassword(), member.getPassword())) {
@@ -114,9 +120,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
 
-    // 회원 삭제 로직
+
+    @Override
     @Transactional
-    public void deleteMember(Member member) {
-        memberRepository.delete(member);
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.findByMemberId(memberId);
+        member.setIsDelete(0);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,9 +19,9 @@ spring:
     activate:
       on-profile: local
   datasource:
-    username: root
-    password: root
-    url: jdbc:mariadb://localhost:3306/edupackdb
+    username: ${DB_USERNAME}
+    password: ${DB_PW}
+    url: ${DB_URL}
     driver-class-name: org.mariadb.jdbc.Driver
   sql:
     init:
@@ -44,9 +44,9 @@ spring:
     activate:
       on-profile: dev
   datasource:
-    username: root
-    password: root
-    url: jdbc:mariadb://localhost:3306/edupackdb
+    username: ${DB_USERNAME}
+    password: ${DB_PW}
+    url: ${DB_URL}
     driver-class-name: org.mariadb.jdbc.Driver
   sql:
     init:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #34

## 📌 개요
- 회원탈퇴 API 구현

## 🔁 변경 사항
- member 관련 CascadeType.ALL 추가
- member 필드 추가 (isDelete) => 회원 탈퇴시 0, 기본 값은 1
- 로그인 로직 수정 (회원 존재 여부 검증 추가)

## 📸 스크린샷

- 회원 탈퇴 api
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/8e9b91f9-a899-4b00-bd84-96c75ac6280f)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/9952888c-a560-453d-846a-f402c6b5d633)

- 회원 탈퇴 후 로그인 결과
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/72e53ab8-2cdf-468c-902f-4f2376a0e3ce)


## 👀 기타 더 이야기해볼 점
- softDelete 방식으로 회원 탈퇴 구현하여 멤버 필드(isDelete) 추가하였습니다!

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
