### PR TITLE
:axe:[Fix]: DiaryAPI수정

### DIFF
--- a/src/main/java/com/app/demo/converter/DiaryConverter.java
+++ b/src/main/java/com/app/demo/converter/DiaryConverter.java
@@ -13,8 +13,6 @@ public class DiaryConverter {
     public static DiaryResponseDTO.DiaryContentDTO toDiaryContentDTO(Diary diary){
         return DiaryResponseDTO.DiaryContentDTO.builder()
                 .id(diary.getDiaryId())
-                .member(diary.getMember())
-                .memberId(diary.getMemberId())
                 .AIEmotion(diary.getAiEmotion())
                 .memberEmotion(diary.getMemberEmotion())
                 .content(diary.getContent())

--- a/src/main/java/com/app/demo/dto/request/DiaryRequestDTO.java
+++ b/src/main/java/com/app/demo/dto/request/DiaryRequestDTO.java
@@ -17,7 +17,7 @@ public class DiaryRequestDTO{
         private Emotion memberEmotion;
         private String pictureKey;
         private LocalDate writtenDate;
-        //private List<Long> musicList;
+        private List<Long> musicList;
     }
 
     @Data

--- a/src/main/java/com/app/demo/dto/request/DiaryRequestDTO.java
+++ b/src/main/java/com/app/demo/dto/request/DiaryRequestDTO.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDate;
+import java.util.List;
+
 public class DiaryRequestDTO{
     @Data
     @Builder
@@ -13,7 +15,6 @@ public class DiaryRequestDTO{
         private Long memberId;
         private String content;
         private Emotion memberEmotion;
-        private Emotion aiEmotion;
         private String pictureKey;
         private LocalDate writtenDate;
         //private List<Long> musicList;

--- a/src/main/java/com/app/demo/dto/response/AIPlaylistResponseDTO.java
+++ b/src/main/java/com/app/demo/dto/response/AIPlaylistResponseDTO.java
@@ -29,7 +29,7 @@ public class AIPlaylistResponseDTO {
     public static class TestDTO{
         private Long memberId;
         private Long diaryId;
-        private Emotion aiEmotion;
+        private List<Float> aiEmotion;
         private LocalDate playlistDate;
     }
 

--- a/src/main/java/com/app/demo/dto/response/DiaryResponseDTO.java
+++ b/src/main/java/com/app/demo/dto/response/DiaryResponseDTO.java
@@ -11,6 +11,7 @@ import lombok.Data;
 
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class DiaryResponseDTO {
 
@@ -29,11 +30,9 @@ public class DiaryResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class DiaryContentDTO {
-        private Member member;
-        private Long memberId;
         private Long id;
         private Emotion memberEmotion;
-        private Emotion AIEmotion;
+        private List<Float> AIEmotion;
         private LocalDate writtenDate;
         private String content;
         private String pictureKey;

--- a/src/main/java/com/app/demo/entity/AIPlaylist.java
+++ b/src/main/java/com/app/demo/entity/AIPlaylist.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Builder
@@ -34,7 +35,7 @@ public class AIPlaylist {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "ai_emotion")
-    private Emotion aiEmotion;
+    private List<Float> aiEmotion;
 
     @Column(name = "playlist_date")
     private LocalDate playlistDate;

--- a/src/main/java/com/app/demo/entity/AIPlaylist.java
+++ b/src/main/java/com/app/demo/entity/AIPlaylist.java
@@ -33,7 +33,6 @@ public class AIPlaylist {
     @Column(name = "diary_id")
     private Long diaryId;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "ai_emotion")
     private List<Float> aiEmotion;
 

--- a/src/main/java/com/app/demo/entity/Diary.java
+++ b/src/main/java/com/app/demo/entity/Diary.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 @Entity
@@ -40,7 +41,7 @@ public class Diary {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "ai_emotion")
-    private Emotion aiEmotion;
+    private List<Float> aiEmotion;
 
     @Column(name = "picture_key", length = 200, nullable = true)
     private String pictureKey;

--- a/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,7 +42,7 @@ public class DiaryServiceImpl implements DiaryService {
     @Override
     public Diary createDiary(DiaryRequestDTO.CreateDiaryRequestDTO requestDTO) {
         Member member = memberRepository.findByMemberId(requestDTO.getMemberId());
-        Emotion aiEmotion = extractAiEmotion(requestDTO.getContent());
+        List<Float> aiEmotion = extractAiEmotion(requestDTO.getContent());
         //List<Long> musicList = requestDTO.getMusicList;
 
         AIPlaylist aiPlaylist = AIPlaylist.builder()
@@ -54,8 +55,6 @@ public class DiaryServiceImpl implements DiaryService {
                 .build();
         //.musicList(musicList)
         Diary diary = Diary.builder()
-                .member(member)
-                .memberId(requestDTO.getMemberId())
                 .content(requestDTO.getContent())
                 .memberEmotion(requestDTO.getMemberEmotion())
                 .aiEmotion(aiEmotion)
@@ -79,8 +78,9 @@ public class DiaryServiceImpl implements DiaryService {
 
     }
 
-    private Emotion extractAiEmotion(String content) {
-        return Emotion.HAPPY;       //더미값
+    private List<Float> extractAiEmotion(String content) {
+        List<Float> aiEmotion = new ArrayList<>();
+        return aiEmotion;
     }
 
     @Override

--- a/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
@@ -43,7 +43,7 @@ public class DiaryServiceImpl implements DiaryService {
     public Diary createDiary(DiaryRequestDTO.CreateDiaryRequestDTO requestDTO) {
         Member member = memberRepository.findByMemberId(requestDTO.getMemberId());
         List<Float> aiEmotion = extractAiEmotion(requestDTO.getContent());
-        //List<Long> musicList = requestDTO.getMusicList;
+        List<Long> musicList = requestDTO.getMusicList();
 
         AIPlaylist aiPlaylist = AIPlaylist.builder()
                 .memberId(requestDTO.getMemberId())


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #36 

## 📌 개요
- Diary관련 수정을 진행했습니다
- aiEmotion의 타입을 변경했습니다.
## 🔁 변경 사항
diary의 responseDTO에서 member와 memberId를 삭제했습니다
diary의 request에 List<Long>musicId를 추가했습니다.
diary에 저장되지는 않지만, Service까지 도착합니다.
musicId는 memberPlaylist를 만드는데 사용됩니다.

aiEmotion을 전부 Emotion타입에서 List<Float>로 변경했습니다

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
