### PR TITLE
🌟  [update]: memberPlaylist 가져오기 + 페이징 처리

### DIFF
--- a/src/main/java/com/app/demo/controller/MemberPlaylistController.java
+++ b/src/main/java/com/app/demo/controller/MemberPlaylistController.java
@@ -16,12 +16,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import com.app.demo.converter.MemberPlaylistConverter;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/playlist")
@@ -38,29 +40,32 @@ public class MemberPlaylistController {
         this.memberPlaylistMusicRepository=memberPlaylistMusicRepository;
     }
 
-/*
+
     @ResponseStatus(code = HttpStatus.OK)
     @Operation(summary = "Member 날짜음악조회", description = "Member플리 날짜로 검색하여 음악 조회 API입니다")
     @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
     @GetMapping("/date/{playlistDate}")
-    public BaseResponse<MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO> getMemberPlaylistMusicsByDate(@RequestParam(name="memberId") Long memberId, @PathVariable LocalDate playlistDate){
-        List<MemberPlaylist> memberPlaylist = memberPlaylistService.getMemberPlaylistByDate(memberId, playlistDate);
-        MemberPlaylistConverter memberPlaylistConverter = new MemberPlaylistConverter(musicRepository, memberPlaylistMusicRepository);
-        MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO memberPlaylistMusicsDTO = memberPlaylistConverter.toMemberPlaylistMusics(memberPlaylist);
-        return BaseResponse.onSuccess(memberPlaylistMusicsDTO);
+    public BaseResponse<List<MemberPlaylistResponseDTO.MusicResponseDTO>> getMemberPlaylistMusicsByDate(@RequestParam(name="memberId") Long memberId,
+                                                                                                        @PathVariable String playlistDate,
+                                                                                                        @RequestParam(defaultValue = "0") int page){
+        LocalDate date = LocalDate.parse(playlistDate);
+        Page<MemberPlaylistResponseDTO.MusicResponseDTO> musicPage = memberPlaylistService.getMemberPlaylistByDate(memberId, date, page);
+        return BaseResponse.onSuccess(musicPage.getContent());
     }
 
- */
 
     @ResponseStatus(code = HttpStatus.OK)
     @Operation(summary = "Member 감정음악조회", description = "Member플리 감정으로 검색하여 음악 조회 API입니다")
     @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "조회성공")})
     @GetMapping("/emotion/{memberEmotion}")
-    public BaseResponse<MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO> getMemberPlaylistMusicsByEmotion(@RequestParam(name="memberId") Long memberId, @PathVariable Emotion memberEmotion){
-        List<MemberPlaylist> memberPlaylistList = memberPlaylistService.getMemberPlaylistListByEmotion(memberId, memberEmotion);
-        MemberPlaylistConverter memberPlaylistConverter = new MemberPlaylistConverter(musicRepository, memberPlaylistMusicRepository);
-        MemberPlaylistResponseDTO.MemberPlaylistMusicsDTO memberPlaylistMusicsDTO = memberPlaylistConverter.toMemberPlaylistListMusics(memberPlaylistList);
-        return BaseResponse.onSuccess(memberPlaylistMusicsDTO);
+    public BaseResponse<List<MemberPlaylistResponseDTO.MusicResponseDTO>> getMemberPlaylistMusicsByEmotion(@RequestParam(name="memberId") Long memberId,
+                                                                                                           @PathVariable Emotion memberEmotion,
+                                                                                                           @RequestParam(defaultValue = "0") int page){
+        List<Music> musicList = memberPlaylistService.getMemberPlaylistListByEmotion(memberId, memberEmotion, page);
+        List<MemberPlaylistResponseDTO.MusicResponseDTO> responseDTOList = musicList.stream()
+                .map(music -> new MemberPlaylistResponseDTO.MusicResponseDTO(music.getId(), music.getTitle(), music.getArtist(), music.getPictureKey()))
+                .collect(Collectors.toList());
+        return BaseResponse.onSuccess(responseDTOList);
     }
 
 

--- a/src/main/java/com/app/demo/converter/MemberPlaylistConverter.java
+++ b/src/main/java/com/app/demo/converter/MemberPlaylistConverter.java
@@ -9,6 +9,7 @@ import com.app.demo.entity.mapping.MemberPlaylistMusic;
 import com.app.demo.repository.MusicRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.app.demo.repository.MemberPlaylistMusicRepository;
+import org.springframework.data.domain.Page;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/app/demo/dto/response/MemberPlaylistResponseDTO.java
+++ b/src/main/java/com/app/demo/dto/response/MemberPlaylistResponseDTO.java
@@ -42,4 +42,15 @@ public class MemberPlaylistResponseDTO {
         private Long diaryId;
         private Diary diary;
     }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MusicResponseDTO{
+        private Long id;
+        private String title;
+        private String artist;
+        private String pictureKey;
+    }
 }

--- a/src/main/java/com/app/demo/entity/enums/Emotion.java
+++ b/src/main/java/com/app/demo/entity/enums/Emotion.java
@@ -5,5 +5,5 @@ public enum Emotion {
     HAPPY,
     ANGRY,
     ROMANCE,
-    ANXIOUS
+    SURPRISE
 }

--- a/src/main/java/com/app/demo/repository/MemberPlaylistMusicRepository.java
+++ b/src/main/java/com/app/demo/repository/MemberPlaylistMusicRepository.java
@@ -3,6 +3,8 @@ package com.app.demo.repository;
 import com.app.demo.entity.MemberPlaylist;
 import com.app.demo.entity.enums.Emotion;
 import com.app.demo.entity.mapping.MemberPlaylistMusic;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,5 +14,6 @@ import java.util.List;
 
 @Repository
 public interface MemberPlaylistMusicRepository extends JpaRepository<MemberPlaylistMusic, Long> {
+    Page<MemberPlaylistMusic> findByMemberPlaylistMemberPlaylistId(Long memberPlaylistId, Pageable pageable);
     List<MemberPlaylistMusic> findByMemberPlaylistMemberPlaylistId(Long memberPlaylistId);
 }

--- a/src/main/java/com/app/demo/repository/MemberPlaylistRepository.java
+++ b/src/main/java/com/app/demo/repository/MemberPlaylistRepository.java
@@ -2,6 +2,8 @@ package com.app.demo.repository;
 
 import com.app.demo.entity.MemberPlaylist;
 import com.app.demo.entity.enums.Emotion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,7 +13,7 @@ import java.util.List;
 @Repository
 public interface MemberPlaylistRepository extends JpaRepository<MemberPlaylist, Long> {
 
-  //  MemberPlaylist findByMemberMemberIdAndPlaylistDate(Long memberId, LocalDate playlistDate);
-    List<MemberPlaylist> findByMemberMemberIdAndMemberEmotion(Long memberId, Emotion memberEmotion);
+    MemberPlaylist findByMemberMemberIdAndPlaylistDate(Long memberId, LocalDate playlistDate);
+    Page<MemberPlaylist> findByMemberMemberIdAndMemberEmotion(Long memberId, Emotion memberEmotion, Pageable pageable);
     List<MemberPlaylist> findByMemberMemberId(Long memberId);
 }

--- a/src/main/java/com/app/demo/service/MemberPlaylistService.java
+++ b/src/main/java/com/app/demo/service/MemberPlaylistService.java
@@ -1,16 +1,18 @@
 package com.app.demo.service;
 
+import com.app.demo.dto.response.MemberPlaylistResponseDTO;
 import com.app.demo.entity.Member;
 import com.app.demo.entity.MemberPlaylist;
 import com.app.demo.entity.enums.Emotion;
 import com.app.demo.entity.Music;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface MemberPlaylistService {
-    MemberPlaylist getMemberPlaylistByDate(Long memberId, LocalDate playlistDate);
-    List<MemberPlaylist> getMemberPlaylistListByEmotion(Long memberId, Emotion memberEmotion);
+    public Page<MemberPlaylistResponseDTO.MusicResponseDTO> getMemberPlaylistByDate(Long memberId, LocalDate playlistDate, int page);
+    List<Music> getMemberPlaylistListByEmotion(Long memberId, Emotion memberEmotion, int page);
     List<MemberPlaylist> getMemberPlaylistListByMemberId(Long memberId);
     MemberPlaylist createMemberPlaylist(Member member, Emotion emotion, LocalDate date);
 }

--- a/src/main/java/com/app/demo/service/impl/MemberPlaylistServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/MemberPlaylistServiceImpl.java
@@ -1,6 +1,7 @@
 package com.app.demo.service.impl;
 
 
+import com.app.demo.dto.response.MemberPlaylistResponseDTO;
 import com.app.demo.entity.AIPlaylist;
 import com.app.demo.entity.Member;
 import com.app.demo.entity.MemberPlaylist;
@@ -9,38 +10,72 @@ import com.app.demo.entity.enums.Emotion;
 import com.app.demo.entity.mapping.MemberPlaylistMusic;
 import com.app.demo.repository.MemberPlaylistMusicRepository;
 import com.app.demo.repository.MemberPlaylistRepository;
+import com.app.demo.repository.MusicRepository;
 import com.app.demo.service.MemberPlaylistService;
 import com.app.demo.service.MusicService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class MemberPlaylistServiceImpl implements MemberPlaylistService {
 
     private final MemberPlaylistRepository memberPlaylistRepository;
-    private MusicService musicService;
+    private final MemberPlaylistMusicRepository memberPlaylistMusicRepository;
+    private final MusicRepository musicRepository;
+    private final MusicService musicService;
 
 
     @Autowired
-    public MemberPlaylistServiceImpl(MemberPlaylistRepository memberPlaylistRepository) {
+    public MemberPlaylistServiceImpl(MemberPlaylistRepository memberPlaylistRepository, MemberPlaylistMusicRepository memberPlaylistMusicRepository, MusicRepository musicRepository, MusicService musicService) {
         this.memberPlaylistRepository = memberPlaylistRepository;
+        this.memberPlaylistMusicRepository = memberPlaylistMusicRepository;
+        this.musicRepository = musicRepository;
+        this.musicService = musicService;
     }
 
     @Override
-    public MemberPlaylist getMemberPlaylistByDate(Long memberId, LocalDate playlistDate) {
-        //return memberPlaylistRepository.findByMemberMemberIdAndPlaylistDate(memberId, playlistDate);
-        return null;
+    public Page<MemberPlaylistResponseDTO.MusicResponseDTO> getMemberPlaylistByDate(Long memberId, LocalDate playlistDate, int page) {
+        MemberPlaylist memberPlaylist = memberPlaylistRepository.findByMemberMemberIdAndPlaylistDate(memberId, playlistDate);
+        if (memberPlaylist == null) {
+            return Page.empty();
+        }
+        Pageable pageable = PageRequest.of(page, 10);
+        Page<MemberPlaylistMusic> memberPlaylistMusicPage = memberPlaylistMusicRepository.findByMemberPlaylistMemberPlaylistId(memberPlaylist.getMemberPlaylistId(), pageable);
+
+        Page<Music> musicPage = memberPlaylistMusicPage.map(mpm -> musicRepository.findById(mpm.getMusic().getId()).orElse(null));
+
+        return memberPlaylistMusicPage.map(mpm -> {
+            Music music = musicRepository.findById(mpm.getMusic().getId()).orElse(null);
+            if (music == null) return null;
+            return new MemberPlaylistResponseDTO.MusicResponseDTO(music.getId(), music.getTitle(), music.getArtist(), music.getPictureKey());
+        });
     }
 
 
 
     @Override
-    public List<MemberPlaylist> getMemberPlaylistListByEmotion(Long memberId, Emotion memberEmotion) {
-        return memberPlaylistRepository.findByMemberMemberIdAndMemberEmotion(memberId, memberEmotion);
+    public List<Music> getMemberPlaylistListByEmotion(Long memberId, Emotion memberEmotion, int page) {
+        Pageable pageable = PageRequest.of(page, 2);
+        Page<MemberPlaylist> memberPlaylistPage = memberPlaylistRepository.findByMemberMemberIdAndMemberEmotion(memberId, memberEmotion, pageable);
+
+
+        List<Music> musicList = new ArrayList<>();
+        for(MemberPlaylist memberPlaylists : memberPlaylistPage.getContent()) {
+            List<MemberPlaylistMusic> memberPlaylistMusic = memberPlaylistMusicRepository.findByMemberPlaylistMemberPlaylistId(memberPlaylists.getMemberPlaylistId());
+            for (MemberPlaylistMusic musics : memberPlaylistMusic) {
+                Optional<Music> music = musicRepository.findById(musics.getMusic().getId());
+                music.ifPresent(musicList::add);
+            }
+        }
+        return musicList;
     }
 
     @Override


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #60

## 📌 개요
- 기존에 Memberplaylist를 가져오는 것에서 memberPlaylistMusic 테이블을 참조하여 음악들 가져오기 + 페이징 처리

## 🔁 변경 사항
- MemberPlaylistMusic을 통해 음악을 가져오도록 구현
- 페이징 처리
- 감정별 playlist 음악 가져오는 거는 playlist 3개씩 한 페이지로 처리하여 playlist에 해당하는 음악들을 가져옴
- 존재하지 않으면 [] 반환

## 📸 스크린샷
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/c4b664fa-8e40-4e22-bd29-21da268ac6e7)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/06f3c9a3-8ae6-4691-8d66-857d6a732efd)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/e7697d68-6e86-4ca2-ab09-b77ea2e88c2e)

![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/62c91b0b-7429-4b77-8de0-78744ff5bbda)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/d6d09707-cff6-4787-8f73-2843fdffd4a5)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/5dcc9c0e-44ac-42d3-b7db-aae05ee79699)

![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/fe07a077-25a9-4979-b985-1e1358293c13)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/a2a0498b-c084-49bb-9555-67241fe8c33b)
![image](https://github.com/SSU-RETURN/emuda-back/assets/109636635/7fc1810a-5d71-493a-ae35-e91a90b697a2)

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
