### PR TITLE
:star2:[Update]: objectException

### DIFF
--- a/src/main/java/com/app/demo/controller/DiaryController.java
+++ b/src/main/java/com/app/demo/controller/DiaryController.java
@@ -89,9 +89,13 @@ public class DiaryController {
     public BaseResponse<DiaryResponseDTO.DiaryIdDTO> createDiary(@RequestPart("diary") DiaryRequestDTO.CreateDiaryRequestDTO requestDTO,
                                                                  @RequestPart(value = "image", required = false) MultipartFile image) {
         String imageUrl = (image != null) ? s3ImageService.upload(image) : null;
-        Diary diary = diaryService.createDiary(requestDTO, imageUrl);
-        DiaryResponseDTO.DiaryIdDTO responseDTO = DiaryConverter.toDiaryIdDTO(diary);
-        return BaseResponse.onSuccess(responseDTO);
+        if(diaryService.getDiaryByMemberDate(requestDTO.getMemberId(), requestDTO.getWrittenDate()) != null){
+            return BaseResponse.onFailure("COMMON400", "이미 오늘의 일기가 존재합니다", null);
+        }else{
+            Diary diary = diaryService.createDiary(requestDTO, imageUrl);
+            DiaryResponseDTO.DiaryIdDTO responseDTO = DiaryConverter.toDiaryIdDTO(diary);
+            return BaseResponse.onSuccess(responseDTO);
+        }
     }
 
     @ResponseStatus(code = HttpStatus.OK)

--- a/src/main/java/com/app/demo/controller/MemberPreferencePlaylistController.java
+++ b/src/main/java/com/app/demo/controller/MemberPreferencePlaylistController.java
@@ -11,6 +11,7 @@ import com.app.demo.entity.Music;
 import com.app.demo.repository.MemberPreferencePlaylistMusicRepository;
 import com.app.demo.repository.MemberRepository;
 import com.app.demo.service.MemberPreferencePlaylistService;
+import com.fasterxml.jackson.databind.ser.Serializers;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -41,9 +42,14 @@ public class MemberPreferencePlaylistController {
     @ApiResponses({@ApiResponse(responseCode = "COMMON201", description="등록성공")})
     @PostMapping("/preference/create")
     public BaseResponse<MemberPreferencePlaylistResponseDTO.CreateMemberPreferencePlaylistDTO> createMemberPreferencePlaylist(@RequestParam Long memberId){
-        MemberPreferencePlaylist memberPreferencePlaylist = memberPreferencePlaylistService.createMemberPreferencePlaylist(memberId);
-        MemberPreferencePlaylistResponseDTO.CreateMemberPreferencePlaylistDTO responseDTO = MemberPreferencePlaylistConverter.toCreateDTO(memberPreferencePlaylist);
-        return BaseResponse.onSuccess(responseDTO);
+
+        if(!memberPreferencePlaylistService.getMemberPreferencePlaylistByMember(memberId).isEmpty()){
+            return BaseResponse.onFailure("COMMON400", "이미 취향플레이리스트가 존재합니다", null);
+        }else {
+            MemberPreferencePlaylist memberPreferencePlaylist = memberPreferencePlaylistService.createMemberPreferencePlaylist(memberId);
+            MemberPreferencePlaylistResponseDTO.CreateMemberPreferencePlaylistDTO responseDTO = MemberPreferencePlaylistConverter.toCreateDTO(memberPreferencePlaylist);
+            return BaseResponse.onSuccess(responseDTO);
+        }
     }
 
     @ResponseStatus(code = HttpStatus.OK)

--- a/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/DiaryServiceImpl.java
@@ -52,6 +52,8 @@ public class DiaryServiceImpl implements DiaryService {
         this.memberPlaylistMusicRepository = memberPlaylistMusicRepository;
     }
 
+
+    @Transactional
     @Override
     public Diary createDiary(DiaryRequestDTO.CreateDiaryRequestDTO requestDTO, String imageUrl) {
         Member member = memberRepository.findByMemberId(requestDTO.getMemberId());


### PR DESCRIPTION

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #90 

## 📌 개요
일기와 플레이리스트가 이미 존재할 때 생성 불가 예외처리

## 🔁 변경 사항
- 일기에 대해서 '오늘의 일기'가 이미 존재할경우 createDiary를 호출했을 때 return 400
- 취향 플레이리스트에 대해서 해당 멤버의 취향 플레이리스트가 이미 존재하면 create~를 호출했을때 return 400
- AI플리, Member플리가 생성될 때 중복을 막기 위해 createDiary에 @Transactional 추가

## 📸 스크린샷
![image](https://github.com/SSU-RETURN/emuda-back/assets/87259867/4c0248fe-a680-4d1c-bdee-92015cbee25a)
취향플리가 없을 때는 정상 생성
![image](https://github.com/SSU-RETURN/emuda-back/assets/87259867/66497eb4-0626-4be4-a4b8-39a4b4a45270)
취향플리가 존재하면 오류
![image](https://github.com/SSU-RETURN/emuda-back/assets/87259867/03e63db8-fa70-423d-b010-46838e870e10)
해당 날짜에 일기가 존재하므로 오류
![image](https://github.com/SSU-RETURN/emuda-back/assets/87259867/45d8cc10-77ce-4658-bde4-fb07fb76ed49)
일기가 없는 날짜엔 정상 생성
## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
