### PR TITLE
:axe:[Fix]: overlappingMusicProblem

### DIFF
--- a/src/main/java/com/app/demo/service/impl/MemberPlaylistServiceImpl.java
+++ b/src/main/java/com/app/demo/service/impl/MemberPlaylistServiceImpl.java
@@ -20,9 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 public class MemberPlaylistServiceImpl implements MemberPlaylistService {
@@ -67,15 +65,16 @@ public class MemberPlaylistServiceImpl implements MemberPlaylistService {
         Page<MemberPlaylist> memberPlaylistPage = memberPlaylistRepository.findByMemberMemberIdAndMemberEmotion(memberId, memberEmotion, pageable);
 
 
-        List<Music> musicList = new ArrayList<>();
+        Set<Music> musicSet = new LinkedHashSet<>();
         for(MemberPlaylist memberPlaylists : memberPlaylistPage.getContent()) {
             List<MemberPlaylistMusic> memberPlaylistMusic = memberPlaylistMusicRepository.findByMemberPlaylistMemberPlaylistId(memberPlaylists.getMemberPlaylistId());
             for (MemberPlaylistMusic musics : memberPlaylistMusic) {
                 Optional<Music> music = musicRepository.findById(musics.getMusic().getId());
-                music.ifPresent(musicList::add);
+                music.ifPresent(musicSet::add);
             }
         }
-        return musicList;
+
+        return new ArrayList<>(musicSet);
     }
 
     @Override


### PR DESCRIPTION

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #106 

## 📌 개요
- getMemberPlaylistByEmotion이 특정 감정의 플레이리스트의 맵핑객체에서 음악만을 가져오는거라서 음악이 중복될 수 있었습니다
- Playlist중, 여러개의 플레이리스트에서 음악을 가져오는건 감정별 멤버 플레이리스트밖에 없어서 해당 플레이리스트만 수정했습니다

## 🔁 변경 사항
List가 아닌 Set으로 플레이리스트를 만들어서 중복객체를 없앴고, 일관성을 위해 마지막에는 List로 변환하여 반환했습니다

## 📸 스크린샷
![image](https://github.com/SSU-RETURN/emuda-back/assets/87259867/5bfec181-6b0d-42ee-a446-c7b6fa6d6440)
![image](https://github.com/SSU-RETURN/emuda-back/assets/87259867/4f2380b6-a842-4d92-8d2c-0e66b1d973de)
다른 날짜에 같은 945번 음악을 memberPlaylist로 넣은 상황입니다

![image](https://github.com/SSU-RETURN/emuda-back/assets/87259867/c20096aa-22a7-4dd5-8384-72127f30c218)
수정전


![image](https://github.com/SSU-RETURN/emuda-back/assets/87259867/ae9f2df9-390c-41ce-a3e4-3ec7645c1aed)
수정후
## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
